### PR TITLE
Bump nodejs helm chart

### DIFF
--- a/charts/et-sya/Chart.yaml
+++ b/charts/et-sya/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: '1.0'
 description: A Helm chart for et-sya App
 name: et-sya
 home: https://github.com/hmcts/et-sya
-version: 0.0.3
+version: 0.0.4
 dependencies:
   - name: nodejs
-    version: 2.3.8
+    version: 2.4.0
     repository: '@hmctspublic'
   - name: idam-pr
     version: 2.2.6


### PR DESCRIPTION
### Change description
Bump nodejs helm chart version as current version is deprecated
https://github.com/hmcts/chart-nodejs/releases

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
