### PR TITLE
Ret 1234 - Task List Employment Details (No Longer Working) - Next layer - Contents

### DIFF
--- a/src/main/controllers/StartDateController.ts
+++ b/src/main/controllers/StartDateController.ts
@@ -49,9 +49,11 @@ export default class StartDateController {
 
   public get = (req: AppRequest, res: Response): void => {
     const content = getPageContent(req, this.startDateContent, [TranslationKeys.COMMON, TranslationKeys.START_DATE]);
+    const employmentStatus = req.session.userCase.isStillWorking;
     assignFormData(req.session.userCase, this.form.getFormFields());
     res.render(TranslationKeys.START_DATE, {
       ...content,
+      employmentStatus,
     });
   };
 }

--- a/src/main/resources/locales/en/translation/start-date.json
+++ b/src/main/resources/locales/en/translation/start-date.json
@@ -1,7 +1,13 @@
 {
   "title": "Employment start date",
   "h1": "Employment start date",
-  "hint": "Tell us when you started working for them.<br>If you do not know the exact date then enter your best estimate <br><br>For example, 22 04 2014",
+  "p1": {
+    "workingOrNotice": "Tell us when you started working for them.",
+    "noLongerWorking": "Tell us when you started working for them. For example, 22 04 2014."
+  },
+  "p2": "If you do not know the exact date then enter your best estimate.",
+  "p3": "For example, 22 04 2014.",
+  "notWorking": "NO LONGER WORKING",
   "errors": {
     "startDate": {
       "required": "Enter your employment start date. For example, 22 04 2014",

--- a/src/main/views/start-date.njk
+++ b/src/main/views/start-date.njk
@@ -14,6 +14,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-4 ">{{ h1 }}</h1>
+      {% if employmentStatus === notWorking %}
+        <p class="govuk-body">
+        {{ p1.noLongerWorking }}<br>
+        {{ p2 }}
+      </p>
+      {% else %}
+        <p class="govuk-body">
+        {{ p1.workingOrNotice }}<br>
+        {{ p2 }}<br><br>
+        {{ p3 }}
+      {% endif %}
     <div>
   <div>
   {% block form %}

--- a/src/test/routes/average-weekly-hours.test.ts
+++ b/src/test/routes/average-weekly-hours.test.ts
@@ -1,11 +1,19 @@
 import request from 'supertest';
 
 import { app } from '../../main/app';
+import { StillWorking } from '../../main/definitions/case';
 import { PageUrls } from '../../main/definitions/constants';
+import { mockApp } from '../unit/mocks/mockApp';
 
 describe(`GET ${PageUrls.AVERAGE_WEEKLY_HOURS}`, () => {
   it('should return the average weekly hours page', async () => {
-    const res = await request(app).get(PageUrls.AVERAGE_WEEKLY_HOURS);
+    const res = await request(
+      mockApp({
+        userCase: {
+          isStillWorking: StillWorking.WORKING || StillWorking.NOTICE || StillWorking.NO_LONGER_WORKING,
+        },
+      })
+    ).get(PageUrls.AVERAGE_WEEKLY_HOURS);
     expect(res.type).toStrictEqual('text/html');
     expect(res.status).toStrictEqual(200);
   });

--- a/src/test/routes/pay-after-tax.test.ts
+++ b/src/test/routes/pay-after-tax.test.ts
@@ -1,11 +1,19 @@
 import request from 'supertest';
 
 import { app } from '../../main/app';
+import { StillWorking } from '../../main/definitions/case';
 import { PageUrls } from '../../main/definitions/constants';
+import { mockApp } from '../unit/mocks/mockApp';
 
 describe(`GET ${PageUrls.PAY_AFTER_TAX}`, () => {
-  it('should return the pay after tax end page', async () => {
-    const res = await request(app).get(PageUrls.PAY_AFTER_TAX);
+  it('should return the pay after tax page', async () => {
+    const res = await request(
+      mockApp({
+        userCase: {
+          isStillWorking: StillWorking.WORKING || StillWorking.NOTICE || StillWorking.NO_LONGER_WORKING,
+        },
+      })
+    ).get(PageUrls.PAY_AFTER_TAX);
     expect(res.type).toStrictEqual('text/html');
     expect(res.status).toStrictEqual(200);
   });

--- a/src/test/routes/pay-before-tax.test.ts
+++ b/src/test/routes/pay-before-tax.test.ts
@@ -1,11 +1,19 @@
 import request from 'supertest';
 
 import { app } from '../../main/app';
+import { StillWorking } from '../../main/definitions/case';
 import { PageUrls } from '../../main/definitions/constants';
+import { mockApp } from '../unit/mocks/mockApp';
 
 describe(`GET ${PageUrls.PAY_BEFORE_TAX}`, () => {
-  it('should return the pay before tax end page', async () => {
-    const res = await request(app).get(PageUrls.PAY_BEFORE_TAX);
+  it('should return the pay before tax page', async () => {
+    const res = await request(
+      mockApp({
+        userCase: {
+          isStillWorking: StillWorking.WORKING || StillWorking.NOTICE || StillWorking.NO_LONGER_WORKING,
+        },
+      })
+    ).get(PageUrls.PAY_BEFORE_TAX);
     expect(res.type).toStrictEqual('text/html');
     expect(res.status).toStrictEqual(200);
   });


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-1234

Start date page was already merged since ticket started so only the end date page content has been added here, along with adjustments to the start date files to display the text for working/notice or no longer working paths.

Also amended some routes test files that were failing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
