### PR TITLE
RET-1028: Add logic that if Redis fails to provide the type of claim, the user is redirected back to type of claim page

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -90,7 +90,11 @@ app.use((req, res) => {
 });
 
 app.use((error: HTTPError, request: Request, response: Response, next: NextFunction) => {
-  if (error.name === RedisErrors.FAILED_TO_CONNECT || error.name === RedisErrors.FAILED_TO_SAVE) {
+  if (
+    error.name === RedisErrors.FAILED_TO_CONNECT ||
+    error.name === RedisErrors.FAILED_TO_SAVE ||
+    error.name === RedisErrors.FAILED_TO_RETREIVE
+  ) {
     request.app.set(RedisErrors.REDIS_ERROR, RedisErrors.DISPLAY_MESSAGE);
     response.redirect(PageUrls.TYPE_OF_CLAIM);
   } else {

--- a/src/main/auth/index.ts
+++ b/src/main/auth/index.ts
@@ -8,7 +8,8 @@ export const getRedirectUrl = (serviceUrl: string, callbackUrlPage: string, guid
   const clientID: string = config.get('services.idam.clientID');
   const loginUrl: string = config.get('services.idam.authorizationURL');
   const callbackUrl = encodeURI(serviceUrl + callbackUrlPage);
-  return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}?guid=${guid}`;
+  const encodedGuid = encodeURIComponent('?guid=' + guid);
+  return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}${encodedGuid}`;
 };
 
 export const getUserDetails = async (

--- a/src/main/auth/index.ts
+++ b/src/main/auth/index.ts
@@ -8,8 +8,7 @@ export const getRedirectUrl = (serviceUrl: string, callbackUrlPage: string, guid
   const clientID: string = config.get('services.idam.clientID');
   const loginUrl: string = config.get('services.idam.authorizationURL');
   const callbackUrl = encodeURI(serviceUrl + callbackUrlPage);
-  const encodedGuid = encodeURIComponent('?guid=' + guid);
-  return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}${encodedGuid}`;
+  return `${loginUrl}?client_id=${clientID}&response_type=code&state=${guid}&redirect_uri=${callbackUrl}`;
 };
 
 export const getUserDetails = async (

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -25,6 +25,8 @@ export class Oidc {
         redisClient.get(guid, (err: Error, typesOfClaim: string) => {
           if (typesOfClaim) {
             req.session.userCase.typeOfClaim = JSON.parse(typesOfClaim);
+          } else {
+            res.redirect(PageUrls.TYPE_OF_CLAIM);
           }
           if (err) {
             const error = new Error(err.message);
@@ -35,6 +37,8 @@ export class Oidc {
             throw error;
           }
         });
+      } else {
+        res.redirect(PageUrls.TYPE_OF_CLAIM);
       }
 
       if (typeof req.query.code === 'string') {

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -20,7 +20,7 @@ export class Oidc {
 
     app.get(AuthUrls.CALLBACK, async (req: AppRequest, res: Response) => {
       const redisClient = req.app.locals?.redisClient;
-      const guid = req.query?.guid;
+      const guid = req.query?.state;
       if (redisClient && guid) {
         redisClient.get(guid, (err: Error, typesOfClaim: string) => {
           if (typesOfClaim) {

--- a/src/test/unit/auth/auth.test.ts
+++ b/src/test/unit/auth/auth.test.ts
@@ -14,8 +14,9 @@ const guid = '4e3cac74-d8cf-4de9-ad20-cf6248ba99aa';
 
 describe('getRedirectUrl', () => {
   test('should create a valid URL to redirect to the login screen', () => {
+    const encoderedGuid = encodeURIComponent(`?guid=${guid}`);
     expect(getRedirectUrl('http://localhost', AuthUrls.CALLBACK, guid)).toBe(
-      `${loginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback?guid=4e3cac74-d8cf-4de9-ad20-cf6248ba99aa`
+      `${loginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback${encoderedGuid}`
     );
   });
 });

--- a/src/test/unit/auth/auth.test.ts
+++ b/src/test/unit/auth/auth.test.ts
@@ -14,9 +14,8 @@ const guid = '4e3cac74-d8cf-4de9-ad20-cf6248ba99aa';
 
 describe('getRedirectUrl', () => {
   test('should create a valid URL to redirect to the login screen', () => {
-    const encoderedGuid = encodeURIComponent(`?guid=${guid}`);
     expect(getRedirectUrl('http://localhost', AuthUrls.CALLBACK, guid)).toBe(
-      `${loginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback${encoderedGuid}`
+      `${loginUrl}?client_id=et-sya&response_type=code&state=${guid}&redirect_uri=http://localhost/oauth2/callback`
     );
   });
 });


### PR DESCRIPTION


https://tools.hmcts.net/jira/browse/RET-1028
### Change description
When this is submitted, as long as the criteria is met, given they are now logged in, they do not need to go back through the authentication pages, so instead, just move to the Interruption or Task 1 page.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
