### PR TITLE
Ret 1020

### DIFF
--- a/charts/et-sya/values.yaml
+++ b/charts/et-sya/values.yaml
@@ -16,6 +16,7 @@ nodejs:
     IDAM_WEB_URL: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/login'
     IDAM_API_URL: 'https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/o/token'
     REDIS_HOST: 'et-sya-session-storage-{{ .Values.global.environment }}.redis.cache.windows.net'
+    ET_SYA_API_HOST: 'et-sya-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'
 
 idam-pr:
   enable: false

--- a/charts/et-sya/values.yaml
+++ b/charts/et-sya/values.yaml
@@ -16,7 +16,7 @@ nodejs:
     IDAM_WEB_URL: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/login'
     IDAM_API_URL: 'https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/o/token'
     REDIS_HOST: 'et-sya-session-storage-{{ .Values.global.environment }}.redis.cache.windows.net'
-    ET_SYA_API_HOST: 'et-sya-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'
+    ET_SYA_API_HOST: 'https://et-sya-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'
 
 idam-pr:
   enable: false

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -10,6 +10,9 @@
     "addressLookup": {
       "url": "ADDRESS_LOOK_UP_URL",
       "token": "ADDRESS_LOOKUP_TOKEN"
+    },
+    "etSyaApi": {
+      "host": "ET_SYA_API_HOST"
     }
   },
   "session": {

--- a/src/main/definitions/constants.ts
+++ b/src/main/definitions/constants.ts
@@ -124,3 +124,13 @@ export const RedisErrors = {
   FAILED_TO_RETREIVE: 'Error when attempting to retreive value from Redis',
   CLIENT_NOT_FOUND: 'Redis client does not exist',
 } as const;
+
+export const CacheMapNames = {
+  CASE_TYPE: 'caseType',
+  TYPES_OF_CLAIM: 'typesOfClaim',
+};
+
+export const CcdDataModel = {
+  SINGLE_CASE: 'ET_EnglandWales',
+  MULTIPLE_CASE: 'ET_EnglandWales_Multiple',
+};

--- a/src/main/services/CacheService.ts
+++ b/src/main/services/CacheService.ts
@@ -2,10 +2,8 @@ import { randomUUID } from 'crypto';
 
 import { RedisClient } from 'redis';
 
-import { TypesOfClaim } from '../definitions/definition';
-
-export const cacheTypesOfClaim = (redisClient: RedisClient, typeOfClaim: TypesOfClaim[]): string => {
+export const cacheTypesOfClaim = (redisClient: RedisClient, cacheMap: Map<string, string>): string => {
   const guid = randomUUID();
-  redisClient.set(guid, JSON.stringify(typeOfClaim));
+  redisClient.set(guid, JSON.stringify(Array.from(cacheMap.entries())));
   return guid;
 };

--- a/src/test/unit/controller/TypeOfClaimController.test.ts
+++ b/src/test/unit/controller/TypeOfClaimController.test.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import redis from 'redis-mock';
 
 import TypeOfClaimController from '../../../main/controllers/TypeOfClaimController';
-import { AuthUrls, RedisErrors, TranslationKeys } from '../../../main/definitions/constants';
+import { AuthUrls, CacheMapNames, RedisErrors, TranslationKeys } from '../../../main/definitions/constants';
 import { TypesOfClaim } from '../../../main/definitions/definition';
 import { cacheTypesOfClaim } from '../../../main/services/CacheService';
 import { mockRequest } from '../mocks/mockRequest';
@@ -75,6 +75,11 @@ describe('Type Of Claim Controller', () => {
       const req = mockRequest({ body });
       const res = mockResponse();
 
+      const cacheMap = new Map<string, string>([
+        [CacheMapNames.CASE_TYPE, undefined],
+        [CacheMapNames.TYPES_OF_CLAIM, JSON.stringify(TypesOfClaim.BREACH_OF_CONTRACT)],
+      ]);
+
       req.app = app;
       req.app.locals = {
         redisClient,
@@ -82,7 +87,7 @@ describe('Type Of Claim Controller', () => {
 
       controller.post(req, res);
 
-      expect(cacheTypesOfClaim).toHaveBeenCalledWith(redisClient, TypesOfClaim.BREACH_OF_CONTRACT);
+      expect(cacheTypesOfClaim).toHaveBeenCalledWith(redisClient, cacheMap);
     });
 
     it('should throw error if Redis client not found', () => {

--- a/src/test/unit/services/CacheService.test.ts
+++ b/src/test/unit/services/CacheService.test.ts
@@ -2,12 +2,17 @@ import { randomUUID } from 'crypto';
 
 import redis from 'redis-mock';
 
+import { YesOrNo } from '../../../main/definitions/case';
+import { CacheMapNames } from '../../../main/definitions/constants';
 import { TypesOfClaim } from '../../../main/definitions/definition';
 import { cacheTypesOfClaim } from '../../../main/services/CacheService';
 
 const redisClient = redis.createClient();
-const typesOfClaim = [TypesOfClaim.BREACH_OF_CONTRACT];
 const uuid = 'f0d62bc6-5c7b-4ac1-98d2-c745a2df79b8';
+const cacheMap = new Map<string, string>([
+  [CacheMapNames.CASE_TYPE, JSON.stringify(YesOrNo.YES)],
+  [CacheMapNames.TYPES_OF_CLAIM, JSON.stringify([TypesOfClaim.BREACH_OF_CONTRACT])],
+]);
 
 jest.mock('crypto');
 const mockedRandomUUID = randomUUID as jest.Mock<string>;
@@ -17,8 +22,8 @@ describe('Cache Types of Claim to Redis', () => {
     mockedRandomUUID.mockImplementation(() => uuid);
     jest.spyOn(redisClient, 'set');
 
-    cacheTypesOfClaim(redisClient, typesOfClaim);
-    expect(redisClient.set).toHaveBeenCalledWith(uuid, JSON.stringify(typesOfClaim));
+    cacheTypesOfClaim(redisClient, cacheMap);
+    expect(redisClient.set).toHaveBeenCalledWith(uuid, JSON.stringify(Array.from(cacheMap.entries())));
   });
 
   it('should return an uuid', () => {
@@ -26,6 +31,6 @@ describe('Cache Types of Claim to Redis', () => {
     jest.spyOn(redisClient, 'set');
     jest.spyOn(redisClient, 'set');
 
-    expect(cacheTypesOfClaim(redisClient, typesOfClaim)).toBe(uuid);
+    expect(cacheTypesOfClaim(redisClient, cacheMap)).toBe(uuid);
   });
 });


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-1020

From the IDAM service, this redirect URL will be provided with a GUID.

If not, then redirect back to "Type of claim" page - retaining the IDAM ID.

If so, then retrieve the 'type of claim' data from Redis via the Cache Service and call the Java
service to initiate the DRAFT claim which will provide a record in JSON format, including the selected claim type option data previously selected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
