### PR TITLE
RET-2530. Don't store links of hublinks, only their statuses.

### DIFF
--- a/src/main/controllers/CitizenHubController.ts
+++ b/src/main/controllers/CitizenHubController.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
 import { PageUrls, TranslationKeys } from '../definitions/constants';
-import { HubLinks, hubLinksMap, sectionIndexToLinkNames } from '../definitions/hub';
+import { HubLinksStatuses, hubLinksMap, sectionIndexToLinkNames } from '../definitions/hub';
 import { AnyRecord } from '../definitions/util-types';
 import { fromApiFormat } from '../helper/ApiFormatter';
 import { currentStateFn } from '../helper/state-sequence';
@@ -34,8 +34,8 @@ export default class CitizenHubController {
     const userCase = req.session.userCase;
     const currentState = currentStateFn(userCase);
 
-    if (!userCase.hubLinks) {
-      userCase.hubLinks = new HubLinks();
+    if (!userCase.hubLinksStatuses) {
+      userCase.hubLinksStatuses = new HubLinksStatuses();
       handleUpdateSubmittedCase(req, logger);
     }
 
@@ -43,12 +43,11 @@ export default class CitizenHubController {
       return {
         title: (l: AnyRecord): string => l[`section${index + 1}`],
         links: sectionIndexToLinkNames[index].map(linkName => {
-          const link = userCase.hubLinks[linkName];
+          const status = userCase.hubLinksStatuses[linkName];
           return {
-            url: link.link,
             linkTxt: (l: AnyRecord): string => l[linkName],
-            status: (l: AnyRecord): string => l[link.status],
-            statusColor: () => hubLinksMap.get(link.status),
+            status: (l: AnyRecord): string => l[status],
+            statusColor: () => hubLinksMap.get(status),
           };
         }),
       };

--- a/src/main/definitions/api/caseApiBody.ts
+++ b/src/main/definitions/api/caseApiBody.ts
@@ -5,7 +5,7 @@ import { ClaimantIndividual } from '../complexTypes/claimantIndividual';
 import { NewEmploymentDetails } from '../complexTypes/newEmploymentDetails';
 import { RespondentType } from '../complexTypes/respondent';
 import { TaskListCheckType } from '../complexTypes/taskListCheckType';
-import { HubLinks } from '../hub';
+import { HubLinksStatuses } from '../hub';
 
 interface CaseDataApiBody {
   caseType: string;
@@ -20,7 +20,7 @@ interface CaseDataApiBody {
   claimantOtherType?: ClaimantEmploymentDetails;
   newEmploymentType?: NewEmploymentDetails;
   respondentCollection?: RespondentRequestBody[];
-  hubLinks?: HubLinks;
+  hubLinksStatuses?: HubLinksStatuses;
 }
 
 export interface CreateCaseBody {

--- a/src/main/definitions/api/caseApiResponse.ts
+++ b/src/main/definitions/api/caseApiResponse.ts
@@ -7,7 +7,7 @@ import { NewEmploymentDetails } from '../complexTypes/newEmploymentDetails';
 import { RespondentType } from '../complexTypes/respondent';
 import { TaskListCheckType } from '../complexTypes/taskListCheckType';
 import { CaseState } from '../definition';
-import { HubLinks } from '../hub';
+import { HubLinksStatuses } from '../hub';
 
 export interface CreateCaseResponse {
   data: CaseApiDataResponse;
@@ -42,7 +42,7 @@ export interface CaseData {
   claimantTaskListChecks?: TaskListCheckType;
   respondentCollection?: RespondentApiModel[];
   et3IsThereAnEt3Response?: YesOrNo;
-  hubLinks?: HubLinks;
+  hubLinksStatuses?: HubLinksStatuses;
 }
 
 export interface RespondentApiModel {

--- a/src/main/definitions/case.ts
+++ b/src/main/definitions/case.ts
@@ -1,5 +1,5 @@
 import { CaseState, ClaimOutcomes, ClaimTypeDiscrimination, ClaimTypePay, TellUsWhatYouWant } from './definition';
-import { HubLinks } from './hub';
+import { HubLinksStatuses } from './hub';
 import { UnknownRecord } from './util-types';
 
 export enum Checkbox {
@@ -118,7 +118,7 @@ export interface Case {
   acasCertNum?: string;
   noAcasReason?: NoAcasNumberReason;
   et3IsThereAnEt3Response?: YesOrNo;
-  hubLinks?: HubLinks;
+  hubLinksStatuses?: HubLinksStatuses;
 }
 
 export const enum StillWorking {

--- a/src/main/definitions/hub.ts
+++ b/src/main/definitions/hub.ts
@@ -11,19 +11,14 @@ export enum HubLinkNames {
   Documents = 'documents',
 }
 
-export class HubLinks {
-  [linkName: string]: HubLink;
+export class HubLinksStatuses {
+  [linkName: string]: HubLinkStatus;
 
   constructor() {
     Object.values(HubLinkNames).forEach(name => {
-      this[name] = { status: HubLinkStatus.NOT_YET_AVAILABLE } as HubLink;
+      this[name] = HubLinkStatus.NOT_YET_AVAILABLE;
     });
   }
-}
-
-export interface HubLink {
-  status: HubLinkStatus;
-  link?: string;
 }
 
 export const enum HubLinkStatus {

--- a/src/main/helper/ApiFormatter.ts
+++ b/src/main/helper/ApiFormatter.ts
@@ -89,7 +89,7 @@ export function fromApiFormat(fromApiCaseData: CaseApiDataResponse): CaseWithId 
     lastModified: convertFromTimestampString(fromApiCaseData.last_modified),
     respondents: mapRespondents(fromApiCaseData.case_data?.respondentCollection),
     et3IsThereAnEt3Response: fromApiCaseData?.case_data?.et3IsThereAnEt3Response,
-    hubLinks: fromApiCaseData?.case_data?.hubLinks,
+    hubLinksStatuses: fromApiCaseData?.case_data?.hubLinksStatuses,
   };
 }
 
@@ -160,7 +160,7 @@ export function toApiFormat(caseItem: CaseWithId): UpdateCaseBody {
         claimDetailsCheck: caseItem.claimDetailsCheck,
       },
       respondentCollection: setRespondentApiFormat(caseItem.respondents),
-      hubLinks: caseItem.hubLinks,
+      hubLinksStatuses: caseItem.hubLinksStatuses,
     },
   };
 }
@@ -244,24 +244,22 @@ export const mapRespondents = (respondents: RespondentApiModel[]): Respondent[] 
   if (respondents === undefined) {
     return;
   }
-  const caseRespondents: Respondent[] = respondents.map(respondent => {
+  return respondents.map(respondent => {
     return {
       respondentName: respondent.value.respondent_name,
     };
   });
-  return caseRespondents;
 };
 
 export const setRespondentApiFormat = (respondents: Respondent[]): RespondentRequestBody[] => {
   if (respondents === undefined) {
     return;
   }
-  const apiFormatRespondents = respondents.map(respondent => {
+  return respondents.map(respondent => {
     return {
       value: {
         respondent_name: respondent.respondentName,
       },
     };
   });
-  return apiFormatRespondents;
 };

--- a/src/main/resources/mocks/mockUserCaseWithCitizenHubLinks.ts
+++ b/src/main/resources/mocks/mockUserCaseWithCitizenHubLinks.ts
@@ -1,20 +1,16 @@
-import { PageUrls } from '../../definitions/constants';
 import { CaseState } from '../../definitions/definition';
-import { HubLinkNames, HubLinkStatus, HubLinks } from '../../definitions/hub';
+import { HubLinkNames, HubLinkStatus, HubLinksStatuses } from '../../definitions/hub';
 
-const hubLinks = new HubLinks();
-Object.keys(hubLinks).forEach(key => {
-  hubLinks[key] = {
-    link: PageUrls.HOME,
-    status: HubLinkStatus.OPTIONAL,
-  };
+const hubLinksStatuses = new HubLinksStatuses();
+Object.keys(hubLinksStatuses).forEach(key => {
+  hubLinksStatuses[key] = HubLinkStatus.OPTIONAL;
 });
 
-hubLinks[HubLinkNames.PersonalDetails].status = HubLinkStatus.SUBMITTED;
-hubLinks[HubLinkNames.Et1ClaimForm].status = HubLinkStatus.SUBMITTED;
-hubLinks[HubLinkNames.RespondentResponse].status = HubLinkStatus.COMPLETED;
-hubLinks[HubLinkNames.HearingDetails].status = HubLinkStatus.NOT_YET_AVAILABLE;
-hubLinks[HubLinkNames.RequestsAndApplications].status = HubLinkStatus.VIEWED;
+hubLinksStatuses[HubLinkNames.PersonalDetails] = HubLinkStatus.SUBMITTED;
+hubLinksStatuses[HubLinkNames.Et1ClaimForm] = HubLinkStatus.SUBMITTED;
+hubLinksStatuses[HubLinkNames.RespondentResponse] = HubLinkStatus.COMPLETED;
+hubLinksStatuses[HubLinkNames.HearingDetails] = HubLinkStatus.NOT_YET_AVAILABLE;
+hubLinksStatuses[HubLinkNames.RequestsAndApplications] = HubLinkStatus.VIEWED;
 
 export default {
   id: '123',
@@ -25,5 +21,5 @@ export default {
   respondents: [{ respondentNumber: 1, respondentName: 'Itay' }],
   createdDate: 'August 19, 2022',
   lastModified: 'August 19, 2022',
-  hubLinks,
+  hubLinksStatuses,
 };

--- a/src/test/unit/helper/ApiFormatter.test.ts
+++ b/src/test/unit/helper/ApiFormatter.test.ts
@@ -16,7 +16,7 @@ import {
   YesOrNoOrNotSure,
 } from '../../../main/definitions/case';
 import { CaseState } from '../../../main/definitions/definition';
-import { HubLinks } from '../../../main/definitions/hub';
+import { HubLinksStatuses } from '../../../main/definitions/hub';
 import {
   formatDate,
   fromApiFormat,
@@ -233,7 +233,7 @@ describe('Format Case Data to Frontend Model', () => {
             },
           },
         ],
-        hubLinks: new HubLinks(),
+        hubLinksStatuses: new HubLinksStatuses(),
       },
     };
     const result = fromApiFormat(mockedApiData);
@@ -299,7 +299,7 @@ describe('Format Case Data to Frontend Model', () => {
         },
       ],
       et3IsThereAnEt3Response: YesOrNo.YES,
-      hubLinks: new HubLinks(),
+      hubLinksStatuses: new HubLinksStatuses(),
     });
   });
 
@@ -368,7 +368,7 @@ describe('Format Case Data to Frontend Model', () => {
       claimDetailsCheck: undefined,
       respondents: undefined,
       et3IsThereAnEt3Response: undefined,
-      hubLinks: undefined,
+      hubLinksStatuses: undefined,
     });
   });
 

--- a/src/test/unit/mocks/mockEt1DataModel.ts
+++ b/src/test/unit/mocks/mockEt1DataModel.ts
@@ -1,4 +1,5 @@
 import { EmailOrPost, HearingPreference, Sex, StillWorking, YesOrNo } from '../../../main/definitions/case';
+import { HubLinkStatus } from '../../../main/definitions/hub';
 
 export const mockEt1DataModel = {
   post_code: 'SW1A 1AA',
@@ -94,37 +95,17 @@ export const mockEt1DataModelUpdate = {
 export const mockEt1DataModelSubmittedUpdate = {
   case_id: '1234',
   case_data: {
-    hubLinks: {
-      contactTribunal: {
-        status: 'notAvailableYet',
-      },
-      documents: {
-        status: 'notAvailableYet',
-      },
-      et1ClaimForm: {
-        status: 'notAvailableYet',
-      },
-      hearingDetails: {
-        status: 'notAvailableYet',
-      },
-      personalDetails: {
-        status: 'notAvailableYet',
-      },
-      requestsAndApplications: {
-        status: 'notAvailableYet',
-      },
-      respondentApplications: {
-        status: 'notAvailableYet',
-      },
-      respondentResponse: {
-        status: 'notAvailableYet',
-      },
-      tribunalJudgements: {
-        status: 'notAvailableYet',
-      },
-      tribunalOrders: {
-        status: 'notAvailableYet',
-      },
+    hubLinksStatuses: {
+      contactTribunal: HubLinkStatus.NOT_YET_AVAILABLE,
+      documents: HubLinkStatus.NOT_YET_AVAILABLE,
+      et1ClaimForm: HubLinkStatus.NOT_YET_AVAILABLE,
+      hearingDetails: HubLinkStatus.NOT_YET_AVAILABLE,
+      personalDetails: HubLinkStatus.NOT_YET_AVAILABLE,
+      requestsAndApplications: HubLinkStatus.NOT_YET_AVAILABLE,
+      respondentApplications: HubLinkStatus.NOT_YET_AVAILABLE,
+      respondentResponse: HubLinkStatus.NOT_YET_AVAILABLE,
+      tribunalJudgements: HubLinkStatus.NOT_YET_AVAILABLE,
+      tribunalOrders: HubLinkStatus.NOT_YET_AVAILABLE,
     },
   },
 };

--- a/src/test/unit/services/CaseService.test.ts
+++ b/src/test/unit/services/CaseService.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../main/definitions/case';
 import { CcdDataModel, JavaApiUrls } from '../../../main/definitions/constants';
 import { CaseState } from '../../../main/definitions/definition';
-import { HubLinks } from '../../../main/definitions/hub';
+import { HubLinksStatuses } from '../../../main/definitions/hub';
 import { CaseApi, UploadedFile, getCaseApi } from '../../../main/services/CaseService';
 import { mockEt1DataModelSubmittedUpdate, mockEt1DataModelUpdate } from '../mocks/mockEt1DataModel';
 
@@ -177,7 +177,7 @@ describe('update case', () => {
       state: CaseState.SUBMITTED,
       createdDate: 'August 19, 2022',
       lastModified: 'August 19, 2022',
-      hubLinks: new HubLinks(),
+      hubLinksStatuses: new HubLinksStatuses(),
     };
     await api.updateSubmittedCase(caseItem);
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-2530
Don't store links of hublinks, only their statuses.

Not backwards compatible but no one has used the links on the hublinks yet so it doesn't really break anything.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
