### PR TITLE
RET-2527: Remove Welsh translation link

### DIFF
--- a/src/main/resources/locales/en/translation/template.json
+++ b/src/main/resources/locales/en/translation/template.json
@@ -10,8 +10,7 @@
   "phaseBanner": {
     "feedback": "Your feedback",
     "smartSurveyFeedbackUrl": "https://www.smartsurvey.co.uk/s/ET_Feedback/?pageurl=",
-    "additionalText": "helps us to improve this service.",
-    "languageToggle": "<a href=\"{currentUrl}{languageFlag}\" class=\"govuk-link language\">Cymraeg</a>"
+    "additionalText": "helps us to improve this service."
   },
   "contactUsTitle": "Contact us",
   "contactUsForHelp": "Telephone: <a href=\"tel:03001231024\" class=\"tel-link\">0300 123 1024</a><br> Telephone: <a href=\"tel:03003035176\" class=\"tel-link\">0300 303 5176</a> (Welsh language)<br>Telephone: <a href=\"tel:03007906234\" class=\"tel-link\">0300 790 6234</a> (Scotland)<br>Textphone: <a href=\"tel:1800103001231024\" class=\"tel-link\">18001 0300 123 1024</a> (England and Wales)<br> Textphone: <a href=\"tel:1800103007906234\" class=\"tel-link\">18001 0300 790 6234</a> (Scotland)<br>Monday to Friday, 9am to 5pm<br> <br><a href=\"https://www.gov.uk/call-charges\" class=\"govuk-link\">Find out about call charges</a>",


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:

### JIRA link
https://tools.hmcts.net/jira/browse/RET-2527

### Change description
Remove option to translate to Welsh

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
