### PR TITLE
RET-2556 Acas, New job date validation

### DIFF
--- a/src/main/components/form/validator.ts
+++ b/src/main/components/form/validator.ts
@@ -214,11 +214,7 @@ export const hasValidFileFormat = (value: Express.Multer.File): string => {
 
 export const isAcasNumberValid: Validator = value => {
   const valueAsString = value as string;
-  if (!/(R(?!\/)([\d/](?!.*\/{2})){10,12}$)/.test(valueAsString)) {
-    return 'invalidAcasNumber';
-  }
-  const lastChar = valueAsString.charAt(valueAsString.length - 1);
-  if (lastChar === '/') {
+  if (!/^[rR]\d{6}\/\d{2}\/\d{2}$/.test(valueAsString)) {
     return 'invalidAcasNumber';
   }
 };

--- a/src/main/definitions/dates.ts
+++ b/src/main/definitions/dates.ts
@@ -80,8 +80,7 @@ export const NewJobDateFormFields = {
   label: (l: AnyRecord): string => l.h1,
   labelHidden: true,
   values: DateValues,
-  validator: (value: CaseDate): DateTypes =>
-    isDateInputInvalid(value) || isDateNotInPast(value) || isDateInNextTenYears(value),
+  validator: (value: CaseDate): DateTypes => isDateInputInvalid(value) || isDateInNextTenYears(value),
 };
 
 export const NoticeEndDateFormFields = {

--- a/src/main/resources/locales/en/translation/tell-us-what-you-want.json
+++ b/src/main/resources/locales/en/translation/tell-us-what-you-want.json
@@ -1,6 +1,6 @@
 {
   "title": "What you want from the claim?",
-  "h1": "What do you want if your claim is successful?",
+  "h1": "What do you want if your claim is successful? (optional)",
   "detailsSummaryComp": "Compensation - what can a tribunal award?",
   "detailsTextComp": {
     "p1": "If a tribunal decides you've been unfairly dismissed, you'll normally receive compensation which is made up of:",
@@ -13,7 +13,10 @@
   },
   "detailsSummaryRecom": "What is a tribunal recommendation?",
   "detailsTextRecom": "If your employer is found to have discriminated against you, a tribunal can make a recommendation that the respondent take specific steps to reduce the effect of the discrimination on you",
-  "compensationOnly": { "title": "Compensation only option", "checkbox": "Compensation only" },
+  "compensationOnly": {
+    "title": "Compensation only option",
+    "checkbox": "Compensation only"
+  },
   "compensationOnlyHint": "You’ll be asked to provide an estimate of total compensation",
   "tribunalRecommendation": {
     "title": "Tribunal recommendation option",

--- a/src/main/resources/locales/en/translation/tribunal-recommendation.json
+++ b/src/main/resources/locales/en/translation/tribunal-recommendation.json
@@ -1,6 +1,6 @@
 {
   "title": "Recommendation request",
-  "h1": "What tribunal recommendation would you like to make?",
+  "h1": "What tribunal recommendation would you like to make? (optional)",
   "detailsSummaryRecom": "What is a tribunal recommendation?",
   "detailsTextRecom": "If your employer is found to have discriminated against you, a tribunal can make a recommendation that the respondent take specific steps to reduce the effect of the discrimination on you",
   "hint": "Tell us what action you’d like a tribunal to recommend your respondents take to reduce the impact of any discrimination which has occurred.",

--- a/src/test/routes/acas-cert-num.test.ts
+++ b/src/test/routes/acas-cert-num.test.ts
@@ -29,7 +29,7 @@ describe(`on POST ${PageUrls.ACAS_CERT_NUM}`, () => {
   test('should go to the types of claim page when the Yes radio button is selected', async () => {
     await request(mockApp({}))
       .post(pageUrl)
-      .send({ acasCertNum: 'R123222/2131', acasCert: YesOrNo.YES })
+      .send({ acasCertNum: 'R123222/21/31', acasCert: YesOrNo.YES })
       .expect(res => {
         expect(res.status).toStrictEqual(302);
         expect(res.header['location']).toStrictEqual(PageUrls.RESPONDENT_DETAILS_CHECK);

--- a/src/test/unit/components/validator.test.ts
+++ b/src/test/unit/components/validator.test.ts
@@ -333,12 +333,6 @@ describe('Validation', () => {
     });
   });
   describe('isAcasNumberValid()', () => {
-    it('Should check if value exist', () => {
-      const isValid = isAcasNumberValid('R12345/789/12');
-
-      expect(isValid).toStrictEqual('invalidAcasNumber');
-    });
-
     it('Should check if value does not exist', () => {
       const isValid = isAcasNumberValid(undefined);
 
@@ -422,6 +416,11 @@ describe('Validation', () => {
     it('Should not allow the slashes in any position', () => {
       const isValid = isAcasNumberValid('R123/45678/12');
       expect(isValid).toStrictEqual('invalidAcasNumber');
+    });
+
+    it('Should allow a small r at the beginning', () => {
+      const isValid = isAcasNumberValid('r123455/79/12');
+      expect(isValid).toStrictEqual(undefined);
     });
 
     it('Should validate corect RNNNNNN/NN/NN format', () => {

--- a/src/test/unit/components/validator.test.ts
+++ b/src/test/unit/components/validator.test.ts
@@ -336,7 +336,7 @@ describe('Validation', () => {
     it('Should check if value exist', () => {
       const isValid = isAcasNumberValid('R12345/789/12');
 
-      expect(isValid).toStrictEqual(undefined);
+      expect(isValid).toStrictEqual('invalidAcasNumber');
     });
 
     it('Should check if value does not exist', () => {
@@ -364,9 +364,13 @@ describe('Validation', () => {
     });
 
     it('Should check if value starts with R', () => {
-      const isValid = isAcasNumberValid('12345/789/123');
+      const beginsWithT = isAcasNumberValid('T123458/89/13');
+      const beginsWithQ = isAcasNumberValid('q123456/78/12');
+      const beginsWithDigit = isAcasNumberValid('1234556/79/12');
 
-      expect(isValid).toStrictEqual('invalidAcasNumber');
+      expect(beginsWithT).toStrictEqual('invalidAcasNumber');
+      expect(beginsWithQ).toStrictEqual('invalidAcasNumber');
+      expect(beginsWithDigit).toStrictEqual('invalidAcasNumber');
     });
 
     it('Should check if has any numeric or / character after R', () => {
@@ -391,6 +395,38 @@ describe('Validation', () => {
       const isValid = isAcasNumberValid('R145123112/');
 
       expect(isValid).toStrictEqual('invalidAcasNumber');
+    });
+
+    it('Should not allow incorrect number of characters in the first digit block', () => {
+      const fiveDigits = isAcasNumberValid('R12345/78/12');
+      const sevenDigits = isAcasNumberValid('R1234567/78/12');
+
+      expect(fiveDigits).toStrictEqual('invalidAcasNumber');
+      expect(sevenDigits).toStrictEqual('invalidAcasNumber');
+    });
+
+    it('Should not allow incorrect number of digits in the middle digit block', () => {
+      const oneDigit = isAcasNumberValid('R123456/321/12');
+      const threeDigits = isAcasNumberValid('R123456/7/12');
+
+      expect(oneDigit).toStrictEqual('invalidAcasNumber');
+      expect(threeDigits).toStrictEqual('invalidAcasNumber');
+    });
+    it('Should not allow incorrect number of digits in the last digit block', () => {
+      const oneDigit = isAcasNumberValid('R123456/32/1');
+      const threeDigits = isAcasNumberValid('R123456/47/124');
+
+      expect(oneDigit).toStrictEqual('invalidAcasNumber');
+      expect(threeDigits).toStrictEqual('invalidAcasNumber');
+    });
+    it('Should not allow the slashes in any position', () => {
+      const isValid = isAcasNumberValid('R123/45678/12');
+      expect(isValid).toStrictEqual('invalidAcasNumber');
+    });
+
+    it('Should validate corect RNNNNNN/NN/NN format', () => {
+      const isValid = isAcasNumberValid('R123456/78/12');
+      expect(isValid).toStrictEqual(undefined);
     });
   });
 });

--- a/src/test/unit/controller/AcasCertNumController.test.ts
+++ b/src/test/unit/controller/AcasCertNumController.test.ts
@@ -25,7 +25,7 @@ describe('Acas Cert Num Controller', () => {
   });
 
   it('should redirect to respondent details check when yes is selected', () => {
-    const body = { acasCert: YesOrNo.YES, acasCertNum: 'R123453/121' };
+    const body = { acasCert: YesOrNo.YES, acasCertNum: 'R123453/12/21' };
 
     const controller = new AcasCertNumController();
 

--- a/src/test/unit/controller/NewJobStartDateController.test.ts
+++ b/src/test/unit/controller/NewJobStartDateController.test.ts
@@ -75,24 +75,6 @@ describe('New Job Start Date Controller', () => {
     expect(req.session.errors).toEqual(errors);
   });
 
-  it('should have error when date is in the past', () => {
-    const errors = [{ propertyName: 'newJobStartDate', errorType: 'invalidDateInPast', fieldName: 'day' }];
-    const body = {
-      'newJobStartDate-day': '12',
-      'newJobStartDate-month': '11',
-      'newJobStartDate-year': '2000',
-    };
-
-    const controller = new NewJobStartDateController(mockLogger);
-
-    const req = mockRequest({ body });
-    const res = mockResponse();
-    controller.post(req, res);
-
-    expect(res.redirect).toHaveBeenCalledWith(req.path);
-    expect(req.session.errors).toEqual(errors);
-  });
-
   it('should render the new job pay page when new job start date is left blank', () => {
     const body = {
       'newJobStartDate-day': '',


### PR DESCRIPTION

### JIRA link


https://tools.hmcts.net/jira/browse/RET-2556

- Update ACAS certificate validation
- removes date in past validation from new job start date
- adds an 'optional' in title to both the tribunal recommendation and what do you want if claim successful pages.

### Change description

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
