### PR TITLE
Ret 2595 - TypeError bug + Acas to lower case

### DIFF
--- a/src/main/helper/ApiFormatter.ts
+++ b/src/main/helper/ApiFormatter.ts
@@ -302,11 +302,11 @@ export const mapRespondents = (respondents: RespondentApiModel[]): Respondent[] 
   return respondents.map(respondent => {
     return {
       respondentName: respondent.value?.respondent_name,
-      respondentAddress1: respondent.value.respondent_address?.AddressLine1,
-      respondentAddress2: respondent.value.respondent_address?.AddressLine2,
-      respondentAddressTown: respondent.value.respondent_address?.PostTown,
-      respondentAddressCountry: respondent.value.respondent_address?.Country,
-      respondentAddressPostcode: respondent.value.respondent_address?.PostCode,
+      respondentAddress1: respondent.value?.respondent_address?.AddressLine1,
+      respondentAddress2: respondent.value?.respondent_address?.AddressLine2,
+      respondentAddressTown: respondent.value?.respondent_address?.PostTown,
+      respondentAddressCountry: respondent.value?.respondent_address?.Country,
+      respondentAddressPostcode: respondent.value?.respondent_address?.PostCode,
       acasCert: respondent.value?.respondent_ACAS_question,
       acasCertNum: respondent.value?.respondent_ACAS,
       noAcasReason: respondent.value?.respondent_ACAS_no,

--- a/src/main/resources/locales/en/translation/respondent-name.json
+++ b/src/main/resources/locales/en/translation/respondent-name.json
@@ -2,7 +2,7 @@
   "title": "Name of the respondent",
   "h1": "What is the name of the respondent you're making the claim against?",
   "p1": "Enter the name of the organisation. If there's no organisation involved - for example, because you were employed by an individual acting as a sole trader - enter the individual's name.",
-  "p2": "This should be the same as the name of the respondent(s) on the ACAS certificate. If they are not the same your claim might be rejected.",
+  "p2": "This should be the same as the name of the respondent(s) on the Acas certificate. If they are not the same your claim might be rejected.",
   "insetText": "You'll be able to add more respondents later if you need to.",
   "label": "Enter name of respondent",
   "errors": {


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/RET-2595
https://tools.hmcts.net/jira/browse/RET-1935

### Change description

1. Fixing typeerror bug when saving empty respondent name as draft. 
2. Fixing Acas upper case inconsistency in respondent name page.
3. 
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
