### PR TITLE
RET-2668: Add Guidance text

### DIFF
--- a/src/main/resources/locales/en/translation/template.json
+++ b/src/main/resources/locales/en/translation/template.json
@@ -13,7 +13,7 @@
     "additionalText": "helps us to improve this service."
   },
   "contactUsTitle": "Contact us",
-  "contactUsForHelp": "Telephone: <a href=\"tel:03001231024\" class=\"tel-link\">0300 123 1024</a><br> Telephone: <a href=\"tel:03003035176\" class=\"tel-link\">0300 303 5176</a> (Welsh language)<br>Telephone: <a href=\"tel:03007906234\" class=\"tel-link\">0300 790 6234</a> (Scotland)<br>Textphone: <a href=\"tel:1800103001231024\" class=\"tel-link\">18001 0300 123 1024</a> (England and Wales)<br> Textphone: <a href=\"tel:1800103007906234\" class=\"tel-link\">18001 0300 790 6234</a> (Scotland)<br>Monday to Friday, 9am to 5pm<br> <br><a href=\"https://www.gov.uk/call-charges\" class=\"govuk-link\">Find out about call charges</a>",
+  "contactUsForHelp": "Call the Employment Tribunal customer contact centre if you have any questions about your claim. They cannot give you legal advice or process any updates to your case.<br><br>Telephone: <a href=\"tel:03001231024\" class=\"tel-link\">0300 123 1024</a><br> Telephone: <a href=\"tel:03003035176\" class=\"tel-link\">0300 303 5176</a> (Welsh language)<br>Telephone: <a href=\"tel:03007906234\" class=\"tel-link\">0300 790 6234</a> (Scotland)<br>Textphone: <a href=\"tel:1800103001231024\" class=\"tel-link\">18001 0300 123 1024</a> (England and Wales)<br> Textphone: <a href=\"tel:1800103007906234\" class=\"tel-link\">18001 0300 790 6234</a> (Scotland)<br>Monday to Friday, 9am to 5pm<br> <br><a href=\"https://www.gov.uk/call-charges\" class=\"govuk-link\">Find out about call charges</a>",
   "noticeLengthInsetText": "If you're not sure, check the terms and conditions of your employment contract.",
   "sessionTimeout": {
     "modal": {

--- a/src/main/resources/locales/en/translation/template.json
+++ b/src/main/resources/locales/en/translation/template.json
@@ -13,7 +13,7 @@
     "additionalText": "helps us to improve this service."
   },
   "contactUsTitle": "Contact us",
-  "contactUsForHelp": "Call the Employment Tribunal customer contact centre if you have any questions about your claim. They cannot give you legal advice or process any updates to your case.<br><br>Telephone: <a href=\"tel:03001231024\" class=\"tel-link\">0300 123 1024</a><br> Telephone: <a href=\"tel:03003035176\" class=\"tel-link\">0300 303 5176</a> (Welsh language)<br>Telephone: <a href=\"tel:03007906234\" class=\"tel-link\">0300 790 6234</a> (Scotland)<br>Textphone: <a href=\"tel:1800103001231024\" class=\"tel-link\">18001 0300 123 1024</a> (England and Wales)<br> Textphone: <a href=\"tel:1800103007906234\" class=\"tel-link\">18001 0300 790 6234</a> (Scotland)<br>Monday to Friday, 9am to 5pm<br> <br><a href=\"https://www.gov.uk/call-charges\" class=\"govuk-link\">Find out about call charges</a>",
+  "contactUsForHelp": "Call one of our Employment Tribunal customer contact centres. They cannot give you legal advice.<br><br>Telephone: 0300 123 1024<br> Telephone: 0300 303 5176(Welsh language)<br>Telephone: 0300 790 6234(Scotland)<br>Textphone: 18001 0300 123 1024(England and Wales)<br>Textphone: 18001 0300 790 6234(Scotland)<br>Monday to Friday, 9am to 5pm<br> <br><a href=\"https://www.gov.uk/call-charges\" class=\"govuk-link\">Find out about call charges</a>",
   "noticeLengthInsetText": "If you're not sure, check the terms and conditions of your employment contract.",
   "sessionTimeout": {
     "modal": {

--- a/src/main/views/home.njk
+++ b/src/main/views/home.njk
@@ -30,7 +30,6 @@
         <li><a href={{PageUrls.RETURN_TO_EXISTING}} class="govuk-link">{{ returnClaimTxt }}</a></li>
       </ul>
       <h2 class="govuk-heading-m">{{ contactUsHelpTitle }}</h2>
-      <p class="govuk-body">{{ contactUsHelpTxt }}</p>
       <p class="govuk-body ">{{ contactUsForHelp|safe }}</p>
     </div>
   </div>


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/RET-2668

### Change description
On expansion of the Contact us link

A critical Guidance text is missing.

Expected: Call one of our Employment Tribunal customer contact centres. They cannot give you legal advice.(screenshot given in https://tools.hmcts.net/jira/browse/RET-1081)

Expected : No Links on the Phone Numbers

Actual : The phone Numbers are Linked.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
