### PR TITLE
RET-2693. Fix multipart form CSRF issue

### DIFF
--- a/src/main/controllers/DescribeWhatHappenedController.ts
+++ b/src/main/controllers/DescribeWhatHappenedController.ts
@@ -107,8 +107,7 @@ export default class DescribeWhatHappenedController {
   };
 
   public get = (req: AppRequest, res: Response): void => {
-    const fileName = getUploadedFileName(req.session?.userCase?.claimSummaryFile?.document_filename);
-    this.uploadedFileName = fileName;
+    this.uploadedFileName = getUploadedFileName(req.session?.userCase?.claimSummaryFile?.document_filename);
     const content = getPageContent(req, this.describeWhatHappenedFormContent, [
       TranslationKeys.COMMON,
       TranslationKeys.DESCRIBE_WHAT_HAPPENED,
@@ -116,6 +115,7 @@ export default class DescribeWhatHappenedController {
     assignFormData(req.session.userCase, this.form.getFormFields());
     res.render(TranslationKeys.DESCRIBE_WHAT_HAPPENED, {
       ...content,
+      postAddress: PageUrls.DESCRIBE_WHAT_HAPPENED,
     });
   };
 }

--- a/src/main/views/form/multipartForm.njk
+++ b/src/main/views/form/multipartForm.njk
@@ -1,7 +1,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-<form class="form" id="main-form" method="post" action="" novalidate="novalidate" enctype="multipart/form-data">
+<!--  Ehe form body will not be parsed until after the request passes that middleware, we need to send the csrf in the action -->
+<form class="form" id="main-form" method="post" action="{{postAddress}}?_csrf={{ csrfToken }}" novalidate="novalidate" enctype="multipart/form-data">
   <input type="hidden" name="_csrf" value={{ csrfToken }}>
   {% block form_content %}
     {% include "./fields.njk" %}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-2693
Send csrf in url as multipart form post requests are first accepted and then reviewed for their body (where the csrf token was).

### Change description

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
