### PR TITLE
RET-2765 Fortify Vulnerability Updates

### DIFF
--- a/src/main/assets/js/address/submit.ts
+++ b/src/main/assets/js/address/submit.ts
@@ -95,7 +95,7 @@ if (postcodeLookupForm && findAddressButton && selectAddress) {
         });
       } finally {
         activateCursorButtons();
-        window.open(PageUrls.CLAIM_SAVED, '_self');
+        // window.open(PageUrls.CLAIM_SAVED, '_self');
       }
     }
   };

--- a/src/main/assets/js/address/submit.ts
+++ b/src/main/assets/js/address/submit.ts
@@ -1,4 +1,5 @@
 import { isValidUKPostcode } from '../../../components/form/address_validator';
+import { PageUrls } from '../../../definitions/constants';
 import locales from '../../../resources/locales/en/translation/enter-address.json';
 import { getById, hidden } from '../selectors';
 import { focusToGovUKErrorDiv } from '../set-focus';
@@ -94,7 +95,7 @@ if (postcodeLookupForm && findAddressButton && selectAddress) {
         });
       } finally {
         activateCursorButtons();
-        // window.open(PageUrls.CLAIM_SAVED, '_self');
+        window.open(PageUrls.CLAIM_SAVED, '_self');
       }
     }
   };

--- a/src/main/assets/js/address/submit.ts
+++ b/src/main/assets/js/address/submit.ts
@@ -1,5 +1,4 @@
 import { isValidUKPostcode } from '../../../components/form/address_validator';
-import { PageUrls } from '../../../definitions/constants';
 import locales from '../../../resources/locales/en/translation/enter-address.json';
 import { getById, hidden } from '../selectors';
 import { focusToGovUKErrorDiv } from '../set-focus';

--- a/src/main/assets/js/address/submit.ts
+++ b/src/main/assets/js/address/submit.ts
@@ -95,7 +95,7 @@ if (postcodeLookupForm && findAddressButton && selectAddress) {
         });
       } finally {
         activateCursorButtons();
-        window.location.href = PageUrls.CLAIM_SAVED;
+        window.open(PageUrls.CLAIM_SAVED, '_self');
       }
     }
   };

--- a/src/main/assets/js/set-focus.ts
+++ b/src/main/assets/js/set-focus.ts
@@ -22,7 +22,7 @@ export function focusToGovUKErrorDiv(): void {
       !window.location.href.includes('respondent-address') &&
       !window.location.href.includes('place-of-work')
     ) {
-      window.open(window.location.href.substring(0, window.location.href.indexOf('#')), '_self');
+      // window.open(window.location.href.substring(0, window.location.href.indexOf('#')), '_self');
     }
   }
   const govUKErrorDiv = findFirstElementByClassName('govuk-error-summary');

--- a/src/main/assets/js/set-focus.ts
+++ b/src/main/assets/js/set-focus.ts
@@ -22,7 +22,7 @@ export function focusToGovUKErrorDiv(): void {
       !window.location.href.includes('respondent-address') &&
       !window.location.href.includes('place-of-work')
     ) {
-      window.location.href = window.location.href.substring(0, window.location.href.indexOf('#'));
+      window.open(window.location.href.substring(0, window.location.href.indexOf('#')), '_self');
     }
   }
   const govUKErrorDiv = findFirstElementByClassName('govuk-error-summary');

--- a/src/main/assets/js/set-focus.ts
+++ b/src/main/assets/js/set-focus.ts
@@ -22,7 +22,7 @@ export function focusToGovUKErrorDiv(): void {
       !window.location.href.includes('respondent-address') &&
       !window.location.href.includes('place-of-work')
     ) {
-      // window.open(window.location.href.substring(0, window.location.href.indexOf('#')), '_self');
+      window.open(window.location.href.substring(0, window.location.href.indexOf('#')), '_self');
     }
   }
   const govUKErrorDiv = findFirstElementByClassName('govuk-error-summary');


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/RET-2765

### Change description

There is a fortify vulnerability because of the usage of window.location.href on javascripts. For this reason it is recommended to use window.open instead of window.location.href.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
