### PR TITLE
RET-2918 BUG: ET1 vetting work address showing as null

### DIFF
--- a/src/main/controllers/WorkAddressController.ts
+++ b/src/main/controllers/WorkAddressController.ts
@@ -44,7 +44,6 @@ export default class WorkAddressController {
     setUserCase(req, this.form);
     const errors = returnSessionErrors(req, this.form);
     if (errors.length === 0 || errors === undefined) {
-      handleUpdateDraftCase(req, logger);
       const isRespondentAndWorkAddressSame = conditionalRedirect(req, this.form.getFormFields(), YesOrNo.YES);
       const redirectUrl = isRespondentAndWorkAddressSame
         ? getRespondentRedirectUrl(req.params.respondentNumber, PageUrls.ACAS_CERT_NUM)
@@ -53,6 +52,7 @@ export default class WorkAddressController {
         const respondentIndex = getRespondentIndex(req);
         updateWorkAddress(req.session.userCase, req.session.userCase.respondents[respondentIndex]);
       }
+      handleUpdateDraftCase(req, logger);
       if (saveForLater) {
         return res.redirect(PageUrls.CLAIM_SAVED);
       } else {

--- a/src/main/controllers/WorkAddressController.ts
+++ b/src/main/controllers/WorkAddressController.ts
@@ -39,7 +39,7 @@ export default class WorkAddressController {
     this.form = new Form(<FormFields>this.workAddressFormContent.fields);
   }
 
-  public post = (req: AppRequest, res: Response): void => {
+  public post = async (req: AppRequest, res: Response): Promise<void> => {
     const { saveForLater } = req.body;
     setUserCase(req, this.form);
     const errors = returnSessionErrors(req, this.form);
@@ -52,7 +52,7 @@ export default class WorkAddressController {
         const respondentIndex = getRespondentIndex(req);
         updateWorkAddress(req.session.userCase, req.session.userCase.respondents[respondentIndex]);
       }
-      handleUpdateDraftCase(req, logger);
+      await handleUpdateDraftCase(req, logger);
       if (saveForLater) {
         return res.redirect(PageUrls.CLAIM_SAVED);
       } else {


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/RET-2918

### Change description

Work address was not setlled right because of the call to backend at line 47. Backend call is moved to line 55 on WorkAddressController.ts file and the issue is resolved

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
