### PR TITLE
RET-3260

### DIFF
--- a/src/main/controllers/helpers/ContactTheTribunalCYAHelper.ts
+++ b/src/main/controllers/helpers/ContactTheTribunalCYAHelper.ts
@@ -86,28 +86,28 @@ export const getCyaContent = (
               ],
             },
           },
-        ]),
-    ...(userCase.copyToOtherPartyYesOrNo === YesOrNo.YES
-      ? []
-      : [
-          {
-            key: {
-              text: translations.copyToOtherPartyText,
-              classes: 'govuk-!-font-weight-regular-m',
-            },
-            value: {
-              text: userCase.copyToOtherPartyText,
-            },
-            actions: {
-              items: [
+          ...(userCase.copyToOtherPartyYesOrNo === YesOrNo.YES
+            ? []
+            : [
                 {
-                  href: PageUrls.COPY_TO_OTHER_PARTY + languageParam,
-                  text: 'Change',
-                  visuallyHiddenText: translations.copyToOtherPartyText,
+                  key: {
+                    text: translations.copyToOtherPartyText,
+                    classes: 'govuk-!-font-weight-regular-m',
+                  },
+                  value: {
+                    text: userCase.copyToOtherPartyText,
+                  },
+                  actions: {
+                    items: [
+                      {
+                        href: PageUrls.COPY_TO_OTHER_PARTY + languageParam,
+                        text: 'Change',
+                        visuallyHiddenText: translations.copyToOtherPartyText,
+                      },
+                    ],
+                  },
                 },
-              ],
-            },
-          },
+              ]),
         ]),
   ];
 };


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/RET-3260

### Change description
Type C applications don't have rule 92 questions asked but currently when finishing a rule 92 application:

actual: fields and 'change' links are shown for rule 92 questions, allowing a user to go to that page and update them.

expected: fields of rule 92 questions shouldn't appear in the CYA page.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
