### PR TITLE
RET-3688: Removed unused notStartedYet notification status

### DIFF
--- a/src/main/controllers/GeneralCorrespondenceNotificationDetailsController.ts
+++ b/src/main/controllers/GeneralCorrespondenceNotificationDetailsController.ts
@@ -17,10 +17,7 @@ export default class GeneralCorrespondenceNotificationDetailsController {
   public get = async (req: AppRequest, res: Response): Promise<void> => {
     const userCase = req.session.userCase;
     const selectedCorrespondence = userCase.sendNotificationCollection.find(it => it.id === req.params.itemId);
-    if (
-      selectedCorrespondence.value.notificationState === HubLinkStatus.NOT_STARTED_YET ||
-      selectedCorrespondence.value.notificationState === HubLinkStatus.NOT_VIEWED
-    ) {
+    if (selectedCorrespondence.value.notificationState === HubLinkStatus.NOT_VIEWED) {
       try {
         selectedCorrespondence.value.notificationState = HubLinkStatus.VIEWED;
         await updateSendNotificationState(req, logger);

--- a/src/main/controllers/helpers/TribunalOrderOrRequestHelper.ts
+++ b/src/main/controllers/helpers/TribunalOrderOrRequestHelper.ts
@@ -169,7 +169,6 @@ export const populateNotificationsWithRedirectLinksAndStatusColors = (
         item.value.sendNotificationResponseTribunal === ResponseRequired.YES &&
         item.value.sendNotificationSelectParties !== Parties.RESPONDENT_ONLY;
       const hasResponded = item.value.respondCollection?.some(r => r.value.from === Applicant.CLAIMANT);
-      const isNotStarted = item.value.notificationState === HubLinkStatus.NOT_STARTED_YET;
       const isNotViewedYet = item.value.notificationState === HubLinkStatus.NOT_VIEWED;
       const isViewed = item.value.notificationState === HubLinkStatus.VIEWED;
 
@@ -182,7 +181,7 @@ export const populateNotificationsWithRedirectLinksAndStatusColors = (
         case responseRequired && !hasResponded:
           hubLinkStatus = HubLinkStatus.NOT_STARTED_YET;
           break;
-        case !responseRequired && (isNotStarted || isNotViewedYet):
+        case !responseRequired && isNotViewedYet:
           hubLinkStatus = HubLinkStatus.NOT_VIEWED;
           break;
         case !responseRequired && isViewed:

--- a/src/test/unit/mocks/mockNotificationItem.ts
+++ b/src/test/unit/mocks/mockNotificationItem.ts
@@ -38,7 +38,7 @@ export const notificationType: SendNotificationType = {
   sendNotificationWhoCaseOrder: 'Judge',
   sendNotificationFullName: 'Bob',
   sendNotificationNotify: 'Both',
-  notificationState: 'notStartedYet',
+  notificationState: 'notViewedYet',
   sendNotificationSubject: [NotificationSubjects.GENERAL_CORRESPONDENCE],
 };
 
@@ -76,7 +76,7 @@ export const notificationRespondentRequiredtoRespond: SendNotificationType = {
   sendNotificationWhoCaseOrder: 'Judge',
   sendNotificationFullName: 'Bob',
   sendNotificationNotify: 'Both',
-  notificationState: 'notStartedYet',
+  notificationState: 'notViewedYet',
   sendNotificationSubject: [NotificationSubjects.GENERAL_CORRESPONDENCE],
 };
 


### PR DESCRIPTION

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
