### PR TITLE
Stop changing respondent applications status when submitting a response from claimant

### DIFF
--- a/src/main/controllers/RespondentApplicationDetailsController.ts
+++ b/src/main/controllers/RespondentApplicationDetailsController.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
+import { YesOrNo } from '../definitions/case';
 import { Applicant, PageUrls, TranslationKeys } from '../definitions/constants';
 import { FormContent } from '../definitions/form';
 import { HubLinkStatus } from '../definitions/hub';
@@ -78,9 +79,13 @@ export default class RespondentApplicationDetailsController {
         case HubLinkStatus.NOT_VIEWED:
           newStatus = HubLinkStatus.VIEWED;
           break;
-        case HubLinkStatus.NOT_STARTED_YET:
         case HubLinkStatus.UPDATED:
           newStatus = HubLinkStatus.IN_PROGRESS;
+          break;
+        case HubLinkStatus.NOT_STARTED_YET:
+          if (YesOrNo.YES !== selectedApplication.value.claimantResponseRequired) {
+            newStatus = HubLinkStatus.IN_PROGRESS;
+          }
           break;
         default:
       }

--- a/src/main/controllers/SubmitRespondentController.ts
+++ b/src/main/controllers/SubmitRespondentController.ts
@@ -2,7 +2,6 @@ import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
 import { PageUrls } from '../definitions/constants';
-import { HubLinkNames, HubLinkStatus } from '../definitions/hub';
 import { getLogger } from '../logger';
 
 import { clearTseFields, handleUpdateHubLinksStatuses, respondToApplication } from './helpers/CaseHelpers';
@@ -13,11 +12,9 @@ const logger = getLogger('SubmitRespondentController');
 export default class SubmitRespondentController {
   public get = async (req: AppRequest, res: Response): Promise<void> => {
     try {
-      const userCase = req.session?.userCase;
-      userCase.hubLinksStatuses[HubLinkNames.RespondentApplications] = HubLinkStatus.IN_PROGRESS;
       await handleUpdateHubLinksStatuses(req, logger);
       await respondToApplication(req, logger);
-      clearTseFields(userCase);
+      clearTseFields(req.session?.userCase);
     } catch (error) {
       logger.info(error.message);
     }

--- a/src/main/definitions/complexTypes/genericTseApplicationTypeItem.ts
+++ b/src/main/definitions/complexTypes/genericTseApplicationTypeItem.ts
@@ -27,6 +27,7 @@ export interface GenericTseApplicationType {
   status?: string;
   dueDate?: string;
   applicationState?: string; // used for CUI and so viewed/not viewed refers to claimant
+  claimantResponseRequired?: string;
   adminDecision?: TseAdminDecisionItem[];
 }
 

--- a/src/test/unit/controller/RespondentApplicationDetailsController.test.ts
+++ b/src/test/unit/controller/RespondentApplicationDetailsController.test.ts
@@ -9,6 +9,7 @@ import { CaseApi } from '../../../main/services/CaseService';
 import {
   mockRespAppWithClaimantResponse,
   mockRespAppWithDecisionNotViewed,
+  mockRespAppWithRespRequstForClaimantInfo,
   mockRespAppWithRespRequstForInfo,
   mockRespAppWithRespRequstForInfoAndReply,
   mockSimpleRespAppTypeItem,
@@ -101,6 +102,21 @@ describe('Respondent application details controller', () => {
 
       expect(response.render).toHaveBeenCalledWith(TranslationKeys.RESPONDENT_APPLICATION_DETAILS, expect.anything());
       expect(request.session.userCase.genericTseApplicationCollection.at(0).value.applicationState).toBe('inProgress');
+    });
+
+    it("doesn't change to inProgress when viewing request for information from claimant", async () => {
+      const userCase: Partial<CaseWithId> = {
+        genericTseApplicationCollection: [clone(mockRespAppWithRespRequstForClaimantInfo)],
+      };
+      const response = mockResponse();
+      const request = mockRequestWithTranslation({ userCase }, respondentApplicationDetailsRaw);
+
+      await new RespondentApplicationDetailsController().get(request, response);
+
+      expect(response.render).toHaveBeenCalledWith(TranslationKeys.RESPONDENT_APPLICATION_DETAILS, expect.anything());
+      expect(request.session.userCase.genericTseApplicationCollection.at(0).value.applicationState).toBe(
+        'notStartedYet'
+      );
     });
   });
 

--- a/src/test/unit/controller/SubmitRespondentController.test.ts
+++ b/src/test/unit/controller/SubmitRespondentController.test.ts
@@ -1,22 +1,10 @@
-import SubmitRespondentController from '../../../main/controllers/SubmitRespondentController';
 import SubmitTseController from '../../../main/controllers/SubmitTribunalCYAController';
 import * as CaseHelper from '../../../main/controllers/helpers/CaseHelpers';
-import { HubLinkNames, HubLinkStatus, HubLinksStatuses } from '../../../main/definitions/hub';
+import { HubLinksStatuses } from '../../../main/definitions/hub';
 import { mockRequest } from '../mocks/mockRequest';
 import { mockResponse } from '../mocks/mockResponse';
 
 describe('Submit respondent controller', () => {
-  it('should change hublink status to IN PROGRESS before submitting the case', () => {
-    const controller = new SubmitRespondentController();
-    const response = mockResponse();
-    const request = mockRequest({});
-    request.session.userCase.hubLinksStatuses = new HubLinksStatuses();
-    controller.get(request, response);
-    expect(request.session.userCase.hubLinksStatuses[HubLinkNames.RespondentApplications]).toStrictEqual(
-      HubLinkStatus.IN_PROGRESS
-    );
-  });
-
   it('should clear TSE fields after submitting the case and updating hublink statuses', async () => {
     const response = mockResponse();
     const request = mockRequest({});

--- a/src/test/unit/mocks/mockApplications.ts
+++ b/src/test/unit/mocks/mockApplications.ts
@@ -193,6 +193,11 @@ export const mockRespAppWithRespRequstForInfo: GenericTseApplicationTypeItem = {
   statusColor: '--blue',
 };
 
+const requestForInfoClone = clone(mockRespAppWithRespRequstForInfo);
+requestForInfoClone.value.claimantResponseRequired = 'Yes';
+requestForInfoClone.value.applicationState = 'notStartedYet';
+export const mockRespAppWithRespRequstForClaimantInfo = requestForInfoClone;
+
 export const mockRespAppWithRespRequstForInfoAndReply: GenericTseApplicationTypeItem = {
   id: '1',
   value: {
@@ -304,4 +309,4 @@ export const mockRespAppWithDecisionNotViewed: GenericTseApplicationType = {
 
 const decisionClone = clone(mockRespAppWithDecisionNotViewed);
 decisionClone.applicationState = HubLinkStatus.VIEWED;
-export const mockRespAppWithDecisionViewed: GenericTseApplicationType = decisionClone;
+export const mockRespAppWithDecisionViewed = decisionClone;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3143,76 +3143,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-core@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@vue/compiler-core@npm:3.3.4"
-  dependencies:
-    "@babel/parser": ^7.21.3
-    "@vue/shared": 3.3.4
-    estree-walker: ^2.0.2
-    source-map-js: ^1.0.2
-  checksum: 5437942ea6575b316c9cd84f4f128a44939713da8b6958060e152c599e6d771d5db056c398d7574ee706ff8092e0d99ac4f14e7eef8712a8dd923d2323201b9e
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-dom@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@vue/compiler-dom@npm:3.3.4"
-  dependencies:
-    "@vue/compiler-core": 3.3.4
-    "@vue/shared": 3.3.4
-  checksum: 1c2ac0c89de8eef7be1c568d57504e6245adaaec40c2c4d9717bc231ca10bf682d918a3b358d24c786eeaf8e0d7eb8a65f57d9044775a304783fde1d069a1896
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-sfc@npm:^3.0.5":
-  version: 3.3.4
-  resolution: "@vue/compiler-sfc@npm:3.3.4"
-  dependencies:
-    "@babel/parser": ^7.20.15
-    "@vue/compiler-core": 3.3.4
-    "@vue/compiler-dom": 3.3.4
-    "@vue/compiler-ssr": 3.3.4
-    "@vue/reactivity-transform": 3.3.4
-    "@vue/shared": 3.3.4
-    estree-walker: ^2.0.2
-    magic-string: ^0.30.0
-    postcss: ^8.1.10
-    source-map-js: ^1.0.2
-  checksum: 0a0adfdd3e812f528e25e4b3bbf14b2296b719a8aac609eca42035295527cc253b918a552dc15218e917efef26b7ca94054dc8784a1a18c06c3d4bb4d18ab8b9
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-ssr@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@vue/compiler-ssr@npm:3.3.4"
-  dependencies:
-    "@vue/compiler-dom": 3.3.4
-    "@vue/shared": 3.3.4
-  checksum: 5d1875d55ea864080dd90e5d81a29f93308e312faf00163db5b391b38c2fe799fd3eb58955823dc632f2f8bdd271a4534cc0020646b7f82717be1a8d30dc16e7
-  languageName: node
-  linkType: hard
-
-"@vue/reactivity-transform@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@vue/reactivity-transform@npm:3.3.4"
-  dependencies:
-    "@babel/parser": ^7.20.15
-    "@vue/compiler-core": 3.3.4
-    "@vue/shared": 3.3.4
-    estree-walker: ^2.0.2
-    magic-string: ^0.30.0
-  checksum: b425e78b2084ac7037887fbe012dcad5e5963ac9714ae15a04fda1c6766ec8c53ef231de1cfdc4d3cf46bd5d84bfec8ebdccf48da4ff5ee2f4b5084e54f0a1b1
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@vue/shared@npm:3.3.4"
-  checksum: 12fe53ff816bfa29ea53f89212067a86512c626b8d30149ff28b36705820f6150e1fb4e4e46897ad9eddb1d1cfc02d8941053939910eed69a905f7a5509baabe
-  languageName: node
-  linkType: hard
-
 "@wdio/config@npm:8.10.1":
   version: 8.10.1
   resolution: "@wdio/config@npm:8.10.1"
@@ -6944,7 +6874,7 @@ __metadata:
     csurf: ^1.11.0
     dayjs: ^1.11.7
     debug: ^4.3.4
-    eslint: ^8.39.0
+    eslint: ^8.43.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-codeceptjs: 1.3.0
     eslint-plugin-import: ^2.27.5


### PR DESCRIPTION
Replaced with new functionality in the citizen hub
https://tools.hmcts.net/jira/browse/RET-3684

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
