### PR TITLE
RET-3684 fixes

### DIFF
--- a/src/main/controllers/citizen-hub/CitizenHubController.ts
+++ b/src/main/controllers/citizen-hub/CitizenHubController.ts
@@ -150,7 +150,8 @@ export default class CitizenHubController {
 
     let respondentBannerContent = undefined;
 
-    if (userCase.hubLinksStatuses[HubLinkNames.RespondentApplications] === HubLinkStatus.IN_PROGRESS) {
+    const respAppsReceived = shouldShowRespondentApplicationReceived(userCase.genericTseApplicationCollection);
+    if (respAppsReceived) {
       respondentBannerContent = getRespondentBannerContent(respondentApplications, translations, languageParam);
     }
 
@@ -180,7 +181,7 @@ export default class CitizenHubController {
       showAcknowledgementAlert: shouldShowAcknowledgementAlert(userCase, hubLinksStatuses),
       showRejectionAlert: shouldShowRejectionAlert(userCase, hubLinksStatuses),
       showRespondentResponseReceived: shouldShowRespondentResponseReceived(hubLinksStatuses),
-      showRespondentApplicationReceived: shouldShowRespondentApplicationReceived(hubLinksStatuses),
+      showRespondentApplicationReceived: respAppsReceived,
       showRespondentRejection: shouldShowRespondentRejection(userCase, hubLinksStatuses),
       showRespondentAcknowledgement: shouldShowRespondentAcknolwedgement(userCase, hubLinksStatuses),
       showJudgmentReceived: shouldShowJudgmentReceived(userCase, hubLinksStatuses),

--- a/src/main/controllers/helpers/CitizenHubHelper.ts
+++ b/src/main/controllers/helpers/CitizenHubHelper.ts
@@ -55,7 +55,7 @@ export const shouldShowRespondentResponseReceived = (hubLinksStatuses: HubLinksS
 // notStartedYet applications can also be ones where the tribunal has asked the claimant for more information.
 // Therefore make sure also that there's a notStartedYet application with no requests for information
 export const shouldShowRespondentApplicationReceived = (applications: GenericTseApplicationTypeItem[]): boolean => {
-  return applications.some(
+  return applications?.some(
     app =>
       app.value.applicationState === HubLinkStatus.NOT_STARTED_YET && app.value.claimantResponseRequired === YesOrNo.NO
   );

--- a/src/main/controllers/helpers/CitizenHubHelper.ts
+++ b/src/main/controllers/helpers/CitizenHubHelper.ts
@@ -51,8 +51,14 @@ export const shouldShowRespondentResponseReceived = (hubLinksStatuses: HubLinksS
   return hubLinksStatuses[HubLinkNames.RespondentResponse] === HubLinkStatus.WAITING_FOR_TRIBUNAL;
 };
 
-export const shouldShowRespondentApplicationReceived = (hubLinksStatuses: HubLinksStatuses): boolean => {
-  return hubLinksStatuses[HubLinkNames.RespondentApplications] === HubLinkStatus.IN_PROGRESS;
+// Only show new respondent applications if there are applications that are not started yet
+// notStartedYet applications can also be ones where the tribunal has asked the claimant for more information.
+// Therefore make sure also that there's a notStartedYet application with no requests for information
+export const shouldShowRespondentApplicationReceived = (applications: GenericTseApplicationTypeItem[]): boolean => {
+  return applications.some(
+    app =>
+      app.value.applicationState === HubLinkStatus.NOT_STARTED_YET && app.value.claimantResponseRequired === YesOrNo.NO
+  );
 };
 
 export const shouldShowRespondentRejection = (userCase: CaseWithId, hubLinksStatuses: HubLinksStatuses): boolean => {

--- a/src/main/controllers/helpers/CitizenHubHelper.ts
+++ b/src/main/controllers/helpers/CitizenHubHelper.ts
@@ -57,7 +57,7 @@ export const shouldShowRespondentResponseReceived = (hubLinksStatuses: HubLinksS
 export const shouldShowRespondentApplicationReceived = (applications: GenericTseApplicationTypeItem[]): boolean => {
   return applications?.some(
     app =>
-      app.value.applicationState === HubLinkStatus.NOT_STARTED_YET && app.value.claimantResponseRequired === YesOrNo.NO
+      app.value.applicationState === HubLinkStatus.NOT_STARTED_YET && app.value.claimantResponseRequired !== YesOrNo.YES
   );
 };
 

--- a/src/main/views/respondent-application-details.njk
+++ b/src/main/views/respondent-application-details.njk
@@ -28,7 +28,8 @@
       {% if respondButton and not isAdminRespondButton %}
         {{ govukButton({
             text: respond,
-            href: redirectUrl
+            href: redirectUrl,
+            id: 'respond-button'
           }) }}
       {% endif %}
 
@@ -38,7 +39,8 @@
         </p>
         {{ govukButton({
             text: respond,
-            href: adminRespondRedirectUrl
+            href: adminRespondRedirectUrl,
+            id: 'respond-button'
           }) }}
       {% endif %}
 

--- a/src/main/views/respondent-application-details.njk
+++ b/src/main/views/respondent-application-details.njk
@@ -25,7 +25,7 @@
       }}
     {% endfor %}
 
-      {% if respondButton %}
+      {% if respondButton and not isAdminRespondButton %}
         {{ govukButton({
             text: respond,
             href: redirectUrl

--- a/src/test/unit/controller/helpers/CitizenHubHelper.test.ts
+++ b/src/test/unit/controller/helpers/CitizenHubHelper.test.ts
@@ -3,8 +3,10 @@ import {
   activateRespondentApplicationsLink,
   checkIfRespondentIsSystemUser,
   shouldHubLinkBeClickable,
+  shouldShowRespondentApplicationReceived,
 } from '../../../../main/controllers/helpers/CitizenHubHelper';
 import { CaseWithId, YesOrNo } from '../../../../main/definitions/case';
+import { GenericTseApplicationTypeItem } from '../../../../main/definitions/complexTypes/genericTseApplicationTypeItem';
 import { CaseState } from '../../../../main/definitions/definition';
 import { HubLinkNames, HubLinkStatus } from '../../../../main/definitions/hub';
 import mockUserCase from '../../mocks/mockUserCase';
@@ -141,5 +143,40 @@ describe('shouldHubLinkBeClickable', () => {
 
   it('should not be clickable otherwise', () => {
     expect(shouldHubLinkBeClickable(HubLinkStatus.IN_PROGRESS, undefined)).toBe(true);
+  });
+});
+
+describe('shouldShowRespondentApplicationReceived', () => {
+  test.each([
+    [
+      [
+        {
+          value: {
+            applicationState: HubLinkStatus.NOT_STARTED_YET,
+            claimantResponseRequired: YesOrNo.NO,
+          },
+        },
+      ],
+      true,
+    ],
+    [
+      [
+        {
+          value: {
+            applicationState: HubLinkStatus.IN_PROGRESS,
+            claimantResponseRequired: YesOrNo.NO,
+          },
+        },
+        {
+          value: {
+            applicationState: HubLinkStatus.NOT_STARTED_YET,
+            claimantResponseRequired: YesOrNo.YES,
+          },
+        },
+      ],
+      false,
+    ],
+  ])('when %j return %s', (applications, expected) => {
+    expect(shouldShowRespondentApplicationReceived(applications as GenericTseApplicationTypeItem[])).toBe(expected);
   });
 });

--- a/src/test/unit/views/respondent-application-details.test.ts
+++ b/src/test/unit/views/respondent-application-details.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 
-import { expect } from 'chai';
 import request from 'supertest';
 
 import { YesOrNo } from '../../../main/definitions/case';
@@ -120,106 +119,97 @@ describe('Respondent Application details page', () => {
 
   it('should display title', () => {
     const title = htmlRes.getElementsByClassName(titleClass);
-    expect(title[0].innerHTML).contains(respondentApplicationDetailsJSON.applicationTo + 'amend response');
+    expect(title[0].innerHTML).toContain(respondentApplicationDetailsJSON.applicationTo + 'amend response');
   });
 
   it('should display respondent application row headers', () => {
     const rowHeader = htmlRes.getElementsByClassName(summaryListKeyClass);
-    expect(rowHeader[0].innerHTML).contains(respondentAppRowHeader1, 'Header does not exist');
-    expect(rowHeader[1].innerHTML).contains(respondentAppRowHeader2, 'Header does not exist');
-    expect(rowHeader[2].innerHTML).contains(respondentAppRowHeader3, 'Header does not exist');
-    expect(rowHeader[3].innerHTML).contains(respondentAppRowHeader4, 'Header does not exist');
-    expect(rowHeader[4].innerHTML).contains(respondentAppRowHeader5, 'Header does not exist');
-    expect(rowHeader[5].innerHTML).contains(respondentAppRowHeader6, 'Header does not exist');
+    expect(rowHeader[0].innerHTML).toContain(respondentAppRowHeader1);
+    expect(rowHeader[1].innerHTML).toContain(respondentAppRowHeader2);
+    expect(rowHeader[2].innerHTML).toContain(respondentAppRowHeader3);
+    expect(rowHeader[3].innerHTML).toContain(respondentAppRowHeader4);
+    expect(rowHeader[4].innerHTML).toContain(respondentAppRowHeader5);
+    expect(rowHeader[5].innerHTML).toContain(respondentAppRowHeader6);
   });
 
   it('should display respondent application details', () => {
     const summaryListData = htmlRes.getElementsByClassName(summaryListValueClass);
-    expect(summaryListData[0].innerHTML).contains('Respondent', 'Applicant does not exist');
-    expect(summaryListData[1].innerHTML).contains('7 March 2023', 'Application type does not exist');
-    expect(summaryListData[2].innerHTML).contains('amend response', 'Application date does not exist');
-    expect(summaryListData[3].innerHTML).contains('Test text', 'Application detail does not exist');
-    expect(summaryListData[4].innerHTML).contains('', 'Supporting material does not exist');
-    expect(summaryListData[5].innerHTML).contains(YesOrNo.YES, 'Rule 92 answer does not exist');
+    expect(summaryListData[0].innerHTML).toContain('Respondent');
+    expect(summaryListData[1].innerHTML).toContain('7 March 2023');
+    expect(summaryListData[2].innerHTML).toContain('amend response');
+    expect(summaryListData[3].innerHTML).toContain('Test text');
+    expect(summaryListData[4].innerHTML).toContain('');
+    expect(summaryListData[5].innerHTML).toContain(YesOrNo.YES);
   });
 
   it('should display claimant response header', () => {
     const title = htmlRes.getElementsByClassName(summaryListTitleClass);
-    expect(title[0].innerHTML).contains(expectedResponseSummaryListHeader);
+    expect(title[0].innerHTML).toContain(expectedResponseSummaryListHeader);
   });
 
   it('should display claimant response row headers', () => {
     const rowHeader = htmlRes.getElementsByClassName(summaryListKeyClass);
-    expect(rowHeader[7].innerHTML).contains(claimantResponseRowHeader1, 'Header does not exist');
-    expect(rowHeader[8].innerHTML).contains(claimantResponseRowHeader2, 'Header does not exist');
-    expect(rowHeader[9].innerHTML).contains(claimantResponseRowHeader3, 'Header does not exist');
-    expect(rowHeader[10].innerHTML).contains(claimantResponseRowHeader4, 'Header does not exist');
-    expect(rowHeader[11].innerHTML).contains(claimantResponseRowHeader5, 'Header does not exist');
+    expect(rowHeader[7].innerHTML).toContain(claimantResponseRowHeader1);
+    expect(rowHeader[8].innerHTML).toContain(claimantResponseRowHeader2);
+    expect(rowHeader[9].innerHTML).toContain(claimantResponseRowHeader3);
+    expect(rowHeader[10].innerHTML).toContain(claimantResponseRowHeader4);
+    expect(rowHeader[11].innerHTML).toContain(claimantResponseRowHeader5);
   });
 
   it('should display claimant response details', () => {
     const summaryListData = htmlRes.getElementsByClassName(summaryListValueClass);
-    expect(summaryListData[6].innerHTML).contains('Claimant', 'Applicant does not exist');
-    expect(summaryListData[7].innerHTML).contains('20 March 2023', 'Application date does not exist');
-    expect(summaryListData[8].innerHTML).contains('Response text', 'Application detail does not exist');
-    expect(summaryListData[9].innerHTML).contains('', 'Supporting material field should be blank');
-    expect(summaryListData[10].innerHTML).contains(YesOrNo.YES, 'Rule 92 answer does not exist');
+    expect(summaryListData[6].innerHTML).toContain('Claimant');
+    expect(summaryListData[7].innerHTML).toContain('20 March 2023');
+    expect(summaryListData[8].innerHTML).toContain('Response text');
+    expect(summaryListData[9].innerHTML).toContain('');
+    expect(summaryListData[10].innerHTML).toContain(YesOrNo.YES);
   });
 
   it('should display admin decision row headers for latest admin decision, with no space at the top of the table', () => {
     const rowHeader = htmlRes.getElementsByClassName(summaryListKeyClass);
-    expect(rowHeader[12].innerHTML).contains(adminDecisionRowHeader1, 'Header does not exist');
-    expect(rowHeader[13].innerHTML).contains(adminDecisionRowHeader2, 'Header does not exist');
-    expect(rowHeader[14].innerHTML).contains(adminDecisionRowHeader3, 'Header does not exist');
-    expect(rowHeader[15].innerHTML).contains(adminDecisionRowHeader4, 'Header does not exist');
-    expect(rowHeader[16].innerHTML).contains(adminDecisionRowHeader5, 'Header does not exist');
-    expect(rowHeader[17].innerHTML).contains(adminDecisionRowHeader6, 'Header does not exist');
-    expect(rowHeader[18].innerHTML).contains(adminDecisionRowHeader7, 'Header does not exist');
-    expect(rowHeader[19].innerHTML).contains(adminDecisionRowHeader8, 'Header does not exist');
-    expect(rowHeader[20].innerHTML).contains(adminDecisionRowHeader9, 'Header does not exist');
-    expect(rowHeader[21].innerHTML).contains(adminDecisionRowHeader10, 'Header does not exist');
+    expect(rowHeader[12].innerHTML).toContain(adminDecisionRowHeader1);
+    expect(rowHeader[13].innerHTML).toContain(adminDecisionRowHeader2);
+    expect(rowHeader[14].innerHTML).toContain(adminDecisionRowHeader3);
+    expect(rowHeader[15].innerHTML).toContain(adminDecisionRowHeader4);
+    expect(rowHeader[16].innerHTML).toContain(adminDecisionRowHeader5);
+    expect(rowHeader[17].innerHTML).toContain(adminDecisionRowHeader6);
+    expect(rowHeader[18].innerHTML).toContain(adminDecisionRowHeader7);
+    expect(rowHeader[19].innerHTML).toContain(adminDecisionRowHeader8);
+    expect(rowHeader[20].innerHTML).toContain(adminDecisionRowHeader9);
+    expect(rowHeader[21].innerHTML).toContain(adminDecisionRowHeader10);
   });
 
   it('if more than one admin decision, should display in order starting with the most recent', () => {
     const summaryListData = htmlRes.getElementsByClassName(summaryListValueClass);
-    expect(summaryListData[11].innerHTML).contains('Decision title 2 test text', 'Decision title does not exist');
-    expect(summaryListData[12].innerHTML).contains('Granted', 'Decision does not exist');
-    expect(summaryListData[13].innerHTML).contains('4 March 2023', 'Decision date does not exist');
-    expect(summaryListData[14].innerHTML).contains('Tribunal', 'Decision maker does not exist');
-    expect(summaryListData[15].innerHTML).contains('Judgment', 'Decision type does not exist');
-    expect(summaryListData[16].innerHTML).contains(
-      'Additional info 2 test text',
-      'Decision additional info does not exist'
-    );
-    expect(summaryListData[17].innerHTML).contains('', 'Supporting material should be blank');
-    expect(summaryListData[18].innerHTML).contains('Judge', 'Decision made by does not exist');
-    expect(summaryListData[19].innerHTML).contains('Mr Decider', 'Decision maker name does not exist');
-    expect(summaryListData[20].innerHTML).contains('Both parties', 'Decision party notification does not exist');
+    expect(summaryListData[11].innerHTML).toContain('Decision title 2 test text');
+    expect(summaryListData[12].innerHTML).toContain('Granted');
+    expect(summaryListData[13].innerHTML).toContain('4 March 2023');
+    expect(summaryListData[14].innerHTML).toContain('Tribunal');
+    expect(summaryListData[15].innerHTML).toContain('Judgment');
+    expect(summaryListData[16].innerHTML).toContain('Additional info 2 test text');
+    expect(summaryListData[17].innerHTML).toContain('');
+    expect(summaryListData[18].innerHTML).toContain('Judge');
+    expect(summaryListData[19].innerHTML).toContain('Mr Decider');
+    expect(summaryListData[20].innerHTML).toContain('Both parties');
   });
 
   it('should display the first row of older admin decisions with a space at the top', () => {
     const rowHeader = htmlRes.getElementsByClassName(summaryListKeyClass);
-    expect(rowHeader[23].innerHTML).contains(adminDecisionRowHeader11, 'Header does not exist');
+    expect(rowHeader[23].innerHTML).toContain(adminDecisionRowHeader11);
   });
 
   it('should display remaining admin decisions in descending order by application number', () => {
     const summaryListData = htmlRes.getElementsByClassName(summaryListValueClass);
-    expect(summaryListData[21].innerHTML).contains(
-      '<br><br>Decision title 1 test text',
-      'Decision title does not exist'
-    );
-    expect(summaryListData[22].innerHTML).contains('Granted', 'Decision does not exist');
-    expect(summaryListData[23].innerHTML).contains('3 March 2023', 'Decision date does not exist');
-    expect(summaryListData[24].innerHTML).contains('Tribunal', 'Decision maker does not exist');
-    expect(summaryListData[25].innerHTML).contains('Judgment', 'Decision type does not exist');
-    expect(summaryListData[26].innerHTML).contains(
-      'Additional info 1 test text',
-      'Decision additional info does not exist'
-    );
-    expect(summaryListData[27].innerHTML).contains('', 'Supporting material should be blank');
-    expect(summaryListData[28].innerHTML).contains('Judge', 'Decision made by does not exist');
-    expect(summaryListData[29].innerHTML).contains('Mr Judgey', 'Decision maker name does not exist');
-    expect(summaryListData[30].innerHTML).contains('Both parties', 'Decision party notification does not exist');
+    expect(summaryListData[21].innerHTML).toContain('<br><br>Decision title 1 test text');
+    expect(summaryListData[22].innerHTML).toContain('Granted');
+    expect(summaryListData[23].innerHTML).toContain('3 March 2023');
+    expect(summaryListData[24].innerHTML).toContain('Tribunal');
+    expect(summaryListData[25].innerHTML).toContain('Judgment');
+    expect(summaryListData[26].innerHTML).toContain('Additional info 1 test text');
+    expect(summaryListData[27].innerHTML).toContain('');
+    expect(summaryListData[28].innerHTML).toContain('Judge');
+    expect(summaryListData[29].innerHTML).toContain('Mr Judgey');
+    expect(summaryListData[30].innerHTML).toContain('Both parties');
   });
 });
 
@@ -285,8 +275,8 @@ describe('reply button link', () => {
     const buttons = htmlRes.getElementsByClassName('govuk-button');
     console.log(JSON.stringify(buttons));
 
-    expect(buttons.length).to.equal(1);
-    expect((buttons[0] as HTMLAnchorElement).href).equal('link');
+    expect(buttons).toHaveLength(1);
+    expect((buttons[0] as HTMLAnchorElement).href).toBe('link');
   });
 
   it('should link to respond-to-respondent', async () => {
@@ -359,7 +349,7 @@ describe('reply button link', () => {
 
     const buttons = htmlRes.getElementsByClassName('govuk-button');
 
-    expect(buttons.length).to.equal(1);
-    expect((buttons[0] as HTMLAnchorElement).href).equal('link');
+    expect(buttons).toHaveLength(1);
+    expect((buttons[0] as HTMLAnchorElement).href).toBe('link');
   });
 });

--- a/src/test/unit/views/respondent-application-details.test.ts
+++ b/src/test/unit/views/respondent-application-details.test.ts
@@ -222,3 +222,144 @@ describe('Respondent Application details page', () => {
     expect(summaryListData[30].innerHTML).contains('Both parties', 'Decision party notification does not exist');
   });
 });
+
+describe('reply button link', () => {
+  it('should link to respond-to-tribunal', async () => {
+    await request(
+      mockApp({
+        userCase: {
+          genericTseApplicationCollection: [
+            {
+              id: 'aae328f0-34f0-48f6-8638-75e3523beb4b',
+              value: {
+                date: '3 July 2023',
+                type: 'Change personal details',
+                number: '1',
+                status: 'Open',
+                details: 'look ma, flexUI populated',
+                dueDate: '10 July 2023',
+                applicant: 'Respondent',
+                responsesCount: '1',
+                applicationState: 'notStartedYet',
+                respondCollection: [
+                  {
+                    id: '77cc7dee-1187-45b1-ad0b-51f4d623efbd',
+                    value: {
+                      date: '3 July 2023',
+                      from: 'Admin',
+                      addDocument: [
+                        {
+                          id: '41266f16-355e-4e31-81a7-7f8e184836b6',
+                          value: {
+                            uploadedDocument: {
+                              document_url: 'http://dm-store:8080/documents/be30afc8-2c18-4f9f-a2ac-9c1b7f7be0da',
+                              document_filename: 'et1_a_b.pdf',
+                              document_binary_url:
+                                'http://dm-store:8080/documents/be30afc8-2c18-4f9f-a2ac-9c1b7f7be0da/binary',
+                            },
+                          },
+                        },
+                      ],
+                      requestMadeBy: 'Legal officer',
+                      isCmoOrRequest: 'Request',
+                      madeByFullName: 'asf',
+                      selectPartyNotify: 'Both parties',
+                      isResponseRequired: 'Yes',
+                      selectPartyRespond: 'Claimant',
+                    },
+                  },
+                ],
+                copyToOtherPartyYesOrNo: YesOrNo.YES,
+                claimantResponseRequired: 'Yes',
+              },
+            },
+          ],
+        },
+      })
+    )
+      .get(reqUrl)
+      .then(res => {
+        htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+      });
+
+    const buttons = htmlRes.getElementsByClassName('govuk-button');
+    console.log(JSON.stringify(buttons));
+
+    expect(buttons.length).equal(0);
+    expect(buttons.item(0).getAttribute('href')).equal('link');
+  });
+
+  it('should link to respond-to-respondent', async () => {
+    await request(
+      mockApp({
+        userCase: {
+          genericTseApplicationCollection: [
+            {
+              id: '12bf94a5-6eca-4124-9c52-5f90534af29c',
+              value: {
+                date: '3 July 2023',
+                type: 'Change personal details',
+                number: '2',
+                status: 'Open',
+                details: 'look ma, flexUI populated',
+                dueDate: '10 July 2023',
+                applicant: 'Respondent',
+                responsesCount: '2',
+                applicationState: 'waitingForTheTribunal',
+                respondCollection: [
+                  {
+                    id: '20587e8a-a55d-4c4e-8a8a-6b0ca2a7d079',
+                    value: {
+                      date: '3 July 2023',
+                      from: 'Admin',
+                      addDocument: [
+                        {
+                          id: '8e7e6325-6f95-4433-aff6-69ee1a744021',
+                          value: {
+                            uploadedDocument: {
+                              document_url: 'http://dm-store:8080/documents/e8f02c1e-e4be-48c8-b7ed-0a6abe399940',
+                              document_filename: 'et1_a_b.pdf',
+                              document_binary_url:
+                                'http://dm-store:8080/documents/e8f02c1e-e4be-48c8-b7ed-0a6abe399940/binary',
+                            },
+                          },
+                        },
+                      ],
+                      requestMadeBy: 'Legal officer',
+                      isCmoOrRequest: 'Request',
+                      madeByFullName: 'sad',
+                      selectPartyNotify: 'Claimant only',
+                      isResponseRequired: 'Yes',
+                      selectPartyRespond: 'Claimant',
+                    },
+                  },
+                  {
+                    id: '272b5e2f-d881-47e8-b6a2-1b4a7c7fd0f9',
+                    value: {
+                      date: '3 July 2023',
+                      from: 'Claimant',
+                      response: 'ads',
+                      copyToOtherParty: 'Yes',
+                      hasSupportingMaterial: YesOrNo.NO,
+                    },
+                  },
+                ],
+                copyToOtherPartyYesOrNo: YesOrNo.YES,
+                claimantResponseRequired: 'No',
+              },
+            },
+          ],
+        },
+      })
+    )
+      .get(reqUrl)
+      .then(res => {
+        htmlRes = new DOMParser().parseFromString(res.text, 'text/html');
+      });
+
+    const buttons = htmlRes.getElementsByClassName('govuk-button');
+
+    expect(buttons.length).equal(0);
+    expect(buttons.item(0).getAttribute('href')).equal('link');
+  });
+});

--- a/src/test/unit/views/respondent-application-details.test.ts
+++ b/src/test/unit/views/respondent-application-details.test.ts
@@ -230,7 +230,7 @@ describe('reply button link', () => {
         userCase: {
           genericTseApplicationCollection: [
             {
-              id: 'aae328f0-34f0-48f6-8638-75e3523beb4b',
+              id: 'abc123',
               value: {
                 date: '3 July 2023',
                 type: 'Change personal details',
@@ -285,8 +285,8 @@ describe('reply button link', () => {
     const buttons = htmlRes.getElementsByClassName('govuk-button');
     console.log(JSON.stringify(buttons));
 
-    expect(buttons.length).equal(0);
-    expect(buttons.item(0).getAttribute('href')).equal('link');
+    expect(buttons.length).to.equal(1);
+    expect((buttons[0] as HTMLAnchorElement).href).equal('link');
   });
 
   it('should link to respond-to-respondent', async () => {
@@ -295,7 +295,7 @@ describe('reply button link', () => {
         userCase: {
           genericTseApplicationCollection: [
             {
-              id: '12bf94a5-6eca-4124-9c52-5f90534af29c',
+              id: 'abc123',
               value: {
                 date: '3 July 2023',
                 type: 'Change personal details',
@@ -359,7 +359,7 @@ describe('reply button link', () => {
 
     const buttons = htmlRes.getElementsByClassName('govuk-button');
 
-    expect(buttons.length).equal(0);
-    expect(buttons.item(0).getAttribute('href')).equal('link');
+    expect(buttons.length).to.equal(1);
+    expect((buttons[0] as HTMLAnchorElement).href).equal('link');
   });
 });


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-3684
Fix notifications banner not showing when new applications are received and stop showing duplicated 'respond' button to respondent TSE application (when tribunal also asks for info)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
