### PR TITLE
RET-3684. Fix banner for all respondent responses to TSE applications

### DIFF
--- a/src/main/controllers/helpers/CitizenHubHelper.ts
+++ b/src/main/controllers/helpers/CitizenHubHelper.ts
@@ -47,15 +47,11 @@ export const shouldShowRejectionAlert = (userCase: CaseWithId, hubLinksStatuses:
   );
 };
 
-// Show response received if there's a respondent application where the respondent responded and hasn't been viewed yet
+// Show response received if there's a respondent application where the respondent was the last to respond
 export const shouldShowRespondentResponseReceived = (applications: GenericTseApplicationTypeItem[]): boolean => {
   return applications?.some(app => {
     const responses = app.value.respondCollection;
-    return (
-      responses &&
-      responses[responses.length - 1].value.from === Applicant.RESPONDENT &&
-      app.value.applicationState === HubLinkStatus.UPDATED
-    );
+    return responses && responses[responses.length - 1].value.from === Applicant.RESPONDENT;
   });
 };
 

--- a/src/main/controllers/helpers/CitizenHubHelper.ts
+++ b/src/main/controllers/helpers/CitizenHubHelper.ts
@@ -51,7 +51,11 @@ export const shouldShowRejectionAlert = (userCase: CaseWithId, hubLinksStatuses:
 export const shouldShowRespondentResponseReceived = (applications: GenericTseApplicationTypeItem[]): boolean => {
   return applications?.some(app => {
     const responses = app.value.respondCollection;
-    return responses && responses[responses.length - 1].value.from === Applicant.RESPONDENT;
+    return (
+      responses &&
+      responses[responses.length - 1].value.from === Applicant.RESPONDENT &&
+      responses[responses.length - 1].value.copyToOtherParty === YesOrNo.YES
+    );
   });
 };
 

--- a/src/test/unit/controller/helpers/CitizenHubHelper.test.ts
+++ b/src/test/unit/controller/helpers/CitizenHubHelper.test.ts
@@ -297,6 +297,7 @@ describe('shouldShowRespondentResponseReceived', () => {
               {
                 value: {
                   from: Applicant.RESPONDENT,
+                  copyToOtherParty: YesOrNo.YES,
                 },
               },
             ],
@@ -318,6 +319,7 @@ describe('shouldShowRespondentResponseReceived', () => {
               {
                 value: {
                   from: Applicant.RESPONDENT,
+                  copyToOtherParty: YesOrNo.YES,
                 },
               },
             ],
@@ -334,6 +336,7 @@ describe('shouldShowRespondentResponseReceived', () => {
               {
                 value: {
                   from: Applicant.CLAIMANT,
+                  copyToOtherParty: YesOrNo.YES,
                 },
               },
             ],
@@ -355,6 +358,29 @@ describe('shouldShowRespondentResponseReceived', () => {
               {
                 value: {
                   from: Applicant.CLAIMANT,
+                  copyToOtherParty: YesOrNo.YES,
+                },
+              },
+            ],
+          },
+        },
+      ],
+      false,
+    ],
+    [
+      [
+        {
+          value: {
+            respondCollection: [
+              {
+                value: {
+                  from: Applicant.RESPONDENT,
+                },
+              },
+              {
+                value: {
+                  from: Applicant.RESPONDENT,
+                  copyToOtherParty: YesOrNo.NO,
                 },
               },
             ],

--- a/src/test/unit/controller/helpers/CitizenHubHelper.test.ts
+++ b/src/test/unit/controller/helpers/CitizenHubHelper.test.ts
@@ -300,7 +300,27 @@ describe('shouldShowRespondentResponseReceived', () => {
                 },
               },
             ],
-            applicationState: HubLinkStatus.UPDATED,
+          },
+        },
+      ],
+      true,
+    ],
+    [
+      [
+        {
+          value: {
+            respondCollection: [
+              {
+                value: {
+                  from: Applicant.CLAIMANT,
+                },
+              },
+              {
+                value: {
+                  from: Applicant.RESPONDENT,
+                },
+              },
+            ],
           },
         },
       ],
@@ -317,7 +337,6 @@ describe('shouldShowRespondentResponseReceived', () => {
                 },
               },
             ],
-            applicationState: HubLinkStatus.UPDATED,
           },
         },
       ],
@@ -333,8 +352,12 @@ describe('shouldShowRespondentResponseReceived', () => {
                   from: Applicant.RESPONDENT,
                 },
               },
+              {
+                value: {
+                  from: Applicant.CLAIMANT,
+                },
+              },
             ],
-            applicationState: HubLinkStatus.VIEWED,
           },
         },
       ],

--- a/src/test/unit/views/citizen-hub.test.ts
+++ b/src/test/unit/views/citizen-hub.test.ts
@@ -272,6 +272,7 @@ describe('Citizen hub page', () => {
                   {
                     value: {
                       from: Applicant.RESPONDENT,
+                      copyToOtherParty: YesOrNo.YES,
                     },
                   },
                 ],


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-3684
Show respondent new response banner for any response, not just to tribunal

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

