### PR TITLE
RET-4086: Removed passing res to helper functions

### DIFF
--- a/src/main/controllers/RespondToTribunalResponseController.ts
+++ b/src/main/controllers/RespondToTribunalResponseController.ts
@@ -101,7 +101,13 @@ export default class RespondToTribunalResponseController {
       ...req.t(TranslationKeys.APPLICATION_DETAILS, { returnObjects: true }),
     };
 
-    const allResponses = await getAllResponses(selectedApplication, translations, req, res);
+    let allResponses;
+    try {
+      allResponses = await getAllResponses(selectedApplication, translations, req);
+    } catch (e) {
+      logger.error(e.message);
+      return res.redirect(ErrorPages.NOT_FOUND);
+    }
 
     const document = selectedApplication.value?.documentUpload;
     if (document) {

--- a/src/main/controllers/helpers/ApplicationDetailsHelper.ts
+++ b/src/main/controllers/helpers/ApplicationDetailsHelper.ts
@@ -1,5 +1,3 @@
-import { Response } from 'express';
-
 import { AppRequest } from '../../definitions/appRequest';
 import { Document, YesOrNo } from '../../definitions/case';
 import {
@@ -195,8 +193,7 @@ export const getTseApplicationDecisionDetails = (
 export const getAllResponses = async (
   selectedApplication: GenericTseApplicationTypeItem,
   translations: AnyRecord,
-  req: AppRequest,
-  res: Response
+  req: AppRequest
 ): Promise<any> => {
   const allResponses: any[] = [];
   const respondCollection = selectedApplication.value.respondCollection;
@@ -209,9 +206,9 @@ export const getAllResponses = async (
       response.value.from === Applicant.CLAIMANT ||
       (response.value.from === Applicant.RESPONDENT && response.value.copyToOtherParty === YesOrNo.YES)
     ) {
-      responseToAdd = await addNonAdminResponse(translations, response, req.session.user?.accessToken, res);
+      responseToAdd = await addNonAdminResponse(translations, response, req.session.user?.accessToken);
     } else if (isSentToClaimantByTribunal(response)) {
-      responseToAdd = await addAdminResponse(allResponses, translations, response, req.session.user?.accessToken, res);
+      responseToAdd = await addAdminResponse(allResponses, translations, response, req.session.user?.accessToken);
       if (response.value.isResponseRequired !== YesOrNo.YES && response.value.viewedByClaimant !== YesOrNo.YES) {
         await getCaseApi(req.session.user?.accessToken).updateResponseAsViewed(
           req.session.userCase,
@@ -229,16 +226,11 @@ export const getAllResponses = async (
 
 const getSupportingMaterialDownloadLink = async (
   responseDoc: Document,
-  accessToken: string,
-  res: Response
+  accessToken: string
 ): Promise<string | void> => {
   let responseDocDownload;
   if (responseDoc !== undefined) {
-    try {
-      await getDocumentAdditionalInformation(responseDoc, accessToken);
-    } catch (err) {
-      return res.redirect('/not-found');
-    }
+    await getDocumentAdditionalInformation(responseDoc, accessToken);
     responseDocDownload = createDownloadLink(responseDoc);
   }
   return responseDocDownload;
@@ -248,8 +240,7 @@ const addAdminResponse = async (
   allResponses: any[],
   translations: AnyRecord,
   response: TseRespondTypeItem,
-  accessToken: string,
-  res: Response
+  accessToken: string
 ): Promise<any> => {
   allResponses.push([
     {
@@ -316,8 +307,7 @@ const addAdminResponse = async (
       value: {
         html: await getSupportingMaterialDownloadLink(
           response.value.addDocument?.find(element => element !== undefined).value.uploadedDocument,
-          accessToken,
-          res
+          accessToken
         ),
       },
     },
@@ -350,8 +340,7 @@ const addAdminResponse = async (
 const addNonAdminResponse = async (
   translations: AnyRecord,
   response: TseRespondTypeItem,
-  accessToken: string,
-  res: Response
+  accessToken: string
 ): Promise<any> => {
   return [
     {
@@ -385,8 +374,7 @@ const addNonAdminResponse = async (
       value: {
         html: await getSupportingMaterialDownloadLink(
           response.value.supportingMaterial?.find(element => element !== undefined).value.uploadedDocument,
-          accessToken,
-          res
+          accessToken
         ),
       },
     },

--- a/src/main/controllers/helpers/JudgmentHelpers.ts
+++ b/src/main/controllers/helpers/JudgmentHelpers.ts
@@ -1,6 +1,3 @@
-import logger from '@pact-foundation/pact/src/common/logger';
-import { Response } from 'express';
-
 import { AppRequest } from '../../definitions/appRequest';
 import { CaseWithId, YesOrNo } from '../../definitions/case';
 import { DocumentTypeItem } from '../../definitions/complexTypes/documentTypeItem';
@@ -53,8 +50,7 @@ export const populateJudgmentItemsWithRedirectLinksCaptionsAndStatusColors = (
 
 export const getJudgmentAttachments = async (
   selectedJudgment: SendNotificationTypeItem,
-  req: AppRequest,
-  res: Response
+  req: AppRequest
 ): Promise<DocumentTypeItem[]> => {
   const judgmentAttachments = [];
   if (selectedJudgment?.value?.sendNotificationUploadDocument) {
@@ -65,12 +61,7 @@ export const getJudgmentAttachments = async (
     }
 
     if (judgmentAttachments.length) {
-      try {
-        await getDocumentsAdditionalInformation(judgmentAttachments, req.session.user?.accessToken);
-      } catch (err) {
-        logger.error(err.message);
-        res.redirect('/not-found');
-      }
+      await getDocumentsAdditionalInformation(judgmentAttachments, req.session.user?.accessToken);
       judgmentAttachments.forEach(it => (it.downloadLink = createDownloadLink(it.value.uploadedDocument)));
     }
   }
@@ -79,8 +70,7 @@ export const getJudgmentAttachments = async (
 
 export const getDecisionAttachments = async (
   selectedDecision: TseAdminDecisionItem,
-  req: AppRequest,
-  res: Response
+  req: AppRequest
 ): Promise<DocumentTypeItem[]> => {
   const decisionAttachments = [];
   for (let i = 0; i < selectedDecision?.value?.responseRequiredDoc?.length; i++) {
@@ -90,12 +80,7 @@ export const getDecisionAttachments = async (
   }
 
   if (decisionAttachments.length) {
-    try {
-      await getDocumentsAdditionalInformation(decisionAttachments, req.session.user?.accessToken);
-    } catch (err) {
-      logger.error(err.message);
-      res.redirect('/not-found');
-    }
+    await getDocumentsAdditionalInformation(decisionAttachments, req.session.user?.accessToken);
     decisionAttachments.forEach(it => (it.downloadLink = createDownloadLink(it.value.uploadedDocument)));
   }
   return decisionAttachments;

--- a/src/main/controllers/helpers/TseRespondentApplicationHelpers.ts
+++ b/src/main/controllers/helpers/TseRespondentApplicationHelpers.ts
@@ -1,6 +1,3 @@
-import { Response } from 'express';
-import { LoggerInstance } from 'winston';
-
 import { AppRequest } from '../../definitions/appRequest';
 import { CaseWithId, Document, YesOrNo } from '../../definitions/case';
 import {
@@ -113,9 +110,7 @@ export const setSelectedTseApplication = (
 
 export const getResponseDocDownloadLink = async (
   selectedApplication: GenericTseApplicationTypeItem,
-  logger: LoggerInstance,
-  accessToken: string,
-  res: Response
+  accessToken: string
 ): Promise<string | void> => {
   let responseDocDownload = undefined;
   let responseDoc = undefined;
@@ -127,12 +122,7 @@ export const getResponseDocDownloadLink = async (
         : selectedApplicationRespondCollection[0].value?.supportingMaterial[0].value.uploadedDocument;
   }
   if (responseDoc !== undefined) {
-    try {
-      await getDocumentAdditionalInformation(responseDoc, accessToken);
-    } catch (err) {
-      logger.error(err.message);
-      return res.redirect('/not-found');
-    }
+    await getDocumentAdditionalInformation(responseDoc, accessToken);
     responseDocDownload = createDownloadLink(responseDoc);
   }
   return responseDocDownload;
@@ -140,29 +130,20 @@ export const getResponseDocDownloadLink = async (
 
 export const getApplicationDocDownloadLink = async (
   selectedApplication: GenericTseApplicationTypeItem,
-  logger: LoggerInstance,
-  accessToken: string,
-  res: Response
+  accessToken: string
 ): Promise<string | void> => {
   const applicationDocDownload = selectedApplication?.value?.documentUpload;
 
   if (applicationDocDownload !== undefined) {
-    try {
-      await getDocumentAdditionalInformation(applicationDocDownload, accessToken);
-    } catch (err) {
-      logger.error(err.message);
-      return res.redirect('/not-found');
-    }
+    await getDocumentAdditionalInformation(applicationDocDownload, accessToken);
   }
   return createDownloadLink(applicationDocDownload);
 };
 
 export const getDecisionContent = async (
-  logger: LoggerInstance,
   selectedApplication: GenericTseApplicationTypeItem,
   translations: AnyRecord,
-  accessToken: string,
-  res: Response
+  accessToken: string
 ): Promise<any[] | void> => {
   const selectedAppAdminDecision = selectedApplication.value?.adminDecision;
   let decisionContent = undefined;
@@ -172,12 +153,7 @@ export const getDecisionContent = async (
   if (decisionDocDownload.length > 0) {
     for (let i = decisionDocDownload.length - 1; i >= 0; i--) {
       if (decisionDocDownload[i]) {
-        try {
-          await getDocumentAdditionalInformation(decisionDocDownload[i], accessToken);
-        } catch (err) {
-          logger.error(err.message);
-          return res.redirect('/not-found');
-        }
+        await getDocumentAdditionalInformation(decisionDocDownload[i], accessToken);
         decisionDocDownloadLink[i] = createDownloadLink(decisionDocDownload[i]);
       }
     }

--- a/src/test/unit/controller/ApplicationDetailsController.test.ts
+++ b/src/test/unit/controller/ApplicationDetailsController.test.ts
@@ -3,11 +3,12 @@ import axios, { AxiosResponse } from 'axios';
 import ApplicationDetailsController from '../../../main/controllers/ApplicationDetailsController';
 import { DocumentDetailsResponse } from '../../../main/definitions/api/documentDetailsResponse';
 import { CaseWithId } from '../../../main/definitions/case';
-import { TranslationKeys } from '../../../main/definitions/constants';
+import { ErrorPages, TranslationKeys } from '../../../main/definitions/constants';
 import applicationDetails from '../../../main/resources/locales/en/translation/application-details.json';
 import common from '../../../main/resources/locales/en/translation/common.json';
 import * as CaseService from '../../../main/services/CaseService';
 import { CaseApi } from '../../../main/services/CaseService';
+import { mockDocumentDetailsResponseData } from '../mocks/mockDocumentDetailsResponse';
 import { mockGenericTseCollection } from '../mocks/mockGenericTseCollection';
 import { mockRequestWithTranslation } from '../mocks/mockRequest';
 import { mockResponse } from '../mocks/mockResponse';
@@ -15,6 +16,7 @@ import mockUserCase from '../mocks/mockUserCase';
 
 jest.mock('axios');
 const caseApi = new CaseApi(axios as jest.Mocked<typeof axios>);
+const documentRejection = Promise.reject(new Error('Mocked failure to get document metadata'));
 
 describe('Claimant Applications Controller', () => {
   const translationJsons = { ...applicationDetails, ...common };
@@ -47,20 +49,26 @@ describe('Claimant Applications Controller', () => {
     expect(response.render).toHaveBeenCalledWith(TranslationKeys.APPLICATION_DETAILS, expect.anything());
   });
 
-  it('should redirect to the claimant not found page', async () => {
-    const mockClient = jest.spyOn(CaseService, 'getCaseApi');
-    mockClient.mockReturnValue(caseApi);
-    caseApi.getDocumentDetails = jest.fn().mockResolvedValue({});
-    const controller = new ApplicationDetailsController();
+  it.each([
+    { name: 'application', url: 'uuid1' },
+    { name: 'response', url: 'uuid2' },
+    { name: 'decision', url: 'uuid3' },
+  ])('should redirect to not found page when $type document cannot be resolved', async args => {
+    caseApi.getDocumentDetails = jest
+      .fn()
+      .mockImplementation(docId =>
+        docId === args.url ? documentRejection : Promise.resolve(mockDocumentDetailsResponseData)
+      );
 
-    const userCase: Partial<CaseWithId> = mockUserCase;
-    userCase.genericTseApplicationCollection = mockGenericTseCollection;
+    const userCase: Partial<CaseWithId> = {
+      genericTseApplicationCollection: mockGenericTseCollection.slice(0, 1),
+    };
 
     const response = mockResponse();
-    const request = mockRequestWithTranslation({ t, userCase }, translationJsons);
+    const request = mockRequestWithTranslation({ userCase }, translationJsons);
 
+    const controller = new ApplicationDetailsController();
     await controller.get(request, response);
-
-    expect(response.redirect).toHaveBeenCalledWith('/not-found');
+    expect(response.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
   });
 });

--- a/src/test/unit/controller/JudgmentDetailsController.test.ts
+++ b/src/test/unit/controller/JudgmentDetailsController.test.ts
@@ -1,16 +1,30 @@
+import axios from 'axios';
+
 import JudgmentDetailsController from '../../../main/controllers/JudgmentDetailsController';
 import { CaseWithId } from '../../../main/definitions/case';
 import { SendNotificationType } from '../../../main/definitions/complexTypes/sendNotificationTypeItem';
-import { PageUrls, ResponseRequired } from '../../../main/definitions/constants';
+import { ErrorPages, PageUrls, ResponseRequired, TranslationKeys } from '../../../main/definitions/constants';
 import commonRaw from '../../../main/resources/locales/en/translation/common.json';
 import judgmentDetailsRaw from '../../../main/resources/locales/en/translation/judgment-details.json';
+import * as caseService from '../../../main/services/CaseService';
+import { CaseApi } from '../../../main/services/CaseService';
+import { mockDocumentDetailsResponseData } from '../mocks/mockDocumentDetailsResponse';
+import { mockGenericTseCollection } from '../mocks/mockGenericTseCollection';
 import { mockRequestWithTranslation } from '../mocks/mockRequest';
 import { mockResponse } from '../mocks/mockResponse';
 
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const getCaseApiMock = jest.spyOn(caseService, 'getCaseApi');
+const api = new CaseApi(mockedAxios);
+
+const documentRejection = Promise.reject(new Error('Mocked failure to get document metadata'));
+
 describe('Judgment Details Controller', () => {
+  getCaseApiMock.mockReturnValue(api);
   const translationJsons = { ...judgmentDetailsRaw, ...commonRaw };
 
-  it('should get judgment details page', () => {
+  it('should get judgment details page', async () => {
     const userCase: Partial<CaseWithId> = {
       sendNotificationCollection: [
         {
@@ -30,7 +44,32 @@ describe('Judgment Details Controller', () => {
     request.params.id = '1';
 
     const controller = new JudgmentDetailsController();
-    controller.get(request, response);
-    expect(response.render).toBeDefined();
+    await controller.get(request, response);
+    expect(response.render).toHaveBeenCalledWith(TranslationKeys.JUDGMENT_DETAILS, expect.anything());
+  });
+
+  it.each([
+    { name: 'application', url: 'uuid1' },
+    { name: 'response', url: 'uuid2' },
+    { name: 'decision', url: 'uuid3' },
+  ])('should redirect to not found page when $type document cannot be resolved', async args => {
+    api.getDocumentDetails = jest
+      .fn()
+      .mockImplementation(docId =>
+        docId === args.url ? documentRejection : Promise.resolve(mockDocumentDetailsResponseData)
+      );
+
+    const userCase: Partial<CaseWithId> = {
+      genericTseApplicationCollection: mockGenericTseCollection.slice(0, 1),
+    };
+
+    const response = mockResponse();
+    const request = mockRequestWithTranslation({ userCase }, translationJsons);
+    request.url = PageUrls.JUDGMENT_DETAILS;
+    request.params.id = '1';
+
+    const controller = new JudgmentDetailsController();
+    await controller.get(request, response);
+    expect(response.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
   });
 });

--- a/src/test/unit/controller/RespondentApplicationDetailsController.test.ts
+++ b/src/test/unit/controller/RespondentApplicationDetailsController.test.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import RespondentApplicationDetailsController from '../../../main/controllers/RespondentApplicationDetailsController';
 import { CaseWithId } from '../../../main/definitions/case';
-import { PageUrls, TranslationKeys } from '../../../main/definitions/constants';
+import { ErrorPages, PageUrls, TranslationKeys } from '../../../main/definitions/constants';
 import respondentApplicationDetailsRaw from '../../../main/resources/locales/en/translation/respondent-application-details.json';
 import * as caseService from '../../../main/services/CaseService';
 import { CaseApi } from '../../../main/services/CaseService';
@@ -14,6 +14,8 @@ import {
   mockRespAppWithRespRequstForInfoAndReply,
   mockSimpleRespAppTypeItem,
 } from '../mocks/mockApplications';
+import { mockDocumentDetailsResponse, mockDocumentDetailsResponseData } from '../mocks/mockDocumentDetailsResponse';
+import { mockGenericTseCollection } from '../mocks/mockGenericTseCollection';
 import { mockRequestWithTranslation } from '../mocks/mockRequest';
 import { mockResponse } from '../mocks/mockResponse';
 import { clone } from '../test-helpers/clone';
@@ -22,6 +24,9 @@ jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 const getCaseApiMock = jest.spyOn(caseService, 'getCaseApi');
 const api = new CaseApi(mockedAxios);
+
+api.getDocumentDetails = jest.fn().mockResolvedValue({ data: mockDocumentDetailsResponse });
+const documentRejection = Promise.reject(new Error('Mocked failure to get document metadata'));
 
 describe('Respondent application details controller', () => {
   getCaseApiMock.mockReturnValue(api);
@@ -138,5 +143,28 @@ describe('Respondent application details controller', () => {
 
     expect(response.redirect).toHaveBeenCalledWith(PageUrls.RESPONDENT_APPLICATIONS);
     expect(request.session.userCase.genericTseApplicationCollection.at(0).value.applicationState).toBe('notViewedYet');
+  });
+
+  it.each([
+    { name: 'application', url: 'uuid1' },
+    { name: 'response', url: 'uuid2' },
+    { name: 'decision', url: 'uuid3' },
+  ])('should redirect to not found page when $type document cannot be resolved', async args => {
+    api.getDocumentDetails = jest
+      .fn()
+      .mockImplementation(docId =>
+        docId === args.url ? documentRejection : Promise.resolve(mockDocumentDetailsResponseData)
+      );
+
+    const userCase: Partial<CaseWithId> = {
+      genericTseApplicationCollection: mockGenericTseCollection.slice(0, 1),
+    };
+
+    const response = mockResponse();
+    const request = mockRequestWithTranslation({ userCase }, respondentApplicationDetailsRaw);
+
+    const controller = new RespondentApplicationDetailsController();
+    await controller.get(request, response);
+    expect(response.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
   });
 });

--- a/src/test/unit/mocks/mockDocumentDetailsResponse.ts
+++ b/src/test/unit/mocks/mockDocumentDetailsResponse.ts
@@ -1,0 +1,19 @@
+import { DocumentDetailsResponse } from '../../../main/definitions/api/documentDetailsResponse';
+
+export const mockDocumentDetailsResponse: DocumentDetailsResponse = {
+  createdOn: '2000-01-01',
+  size: 420,
+  mimeType: 'application/pdf',
+  classification: 'PUBLIC',
+  originalDocumentName: 'mockDocumentName',
+  createdBy: 'mockCreatedBy',
+  lastModifiedBy: 'mockLastModifiedBy',
+  modifiedOn: '2000-01-01',
+  metadata: {
+    jurisdiction: 'EMPLOYMENT',
+    case_id: '1',
+    case_type_id: '1',
+  },
+};
+
+export const mockDocumentDetailsResponseData = { data: mockDocumentDetailsResponse };

--- a/src/test/unit/mocks/mockRequest.ts
+++ b/src/test/unit/mocks/mockRequest.ts
@@ -147,6 +147,7 @@ export const mockRequestWithTranslation = (
     save: jest.fn(done => (done ? done() : true)),
     lang: 'en',
     errors: undefined,
+    user: { accessToken: 'token' },
   } as unknown as AppSession;
   return req;
 };


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/RET-4086

### Change description

*This is a subset of the big RET-4086 PR*

Removing passing res to helper functions, handling redirects in their respective controllers (with tests)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
