### PR TITLE
Fix lint-staged silliness (sorry guys!)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+yarn lint-staged
 echo "Nice commit pal."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-lint-staged
+
 ./yarn-audit-with-suppressions.sh


### PR DESCRIPTION
### Change description
Fixing my silly error wherein I got it to check for staged files after they'd already been committed.
Thanks @JackReevies for pointing it out kindly 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
