### PR TITLE
RET-4334 - Redirect to Error Page when Catching Error

### DIFF
--- a/src/main/controllers/AllDocumentsController.ts
+++ b/src/main/controllers/AllDocumentsController.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
-import { AllDocumentTypes, PageUrls, TranslationKeys } from '../definitions/constants';
+import { AllDocumentTypes, ErrorPages, PageUrls, TranslationKeys } from '../definitions/constants';
 import { FormContent } from '../definitions/form';
 import { AnyRecord } from '../definitions/util-types';
 import { getLogger } from '../logger';
@@ -37,7 +37,7 @@ export default class AllDocumentsController {
         await getDocumentsAdditionalInformation(docCollection, req.session.user?.accessToken);
       } catch (err) {
         logger.error(err.message);
-        res.redirect('/not-found');
+        res.redirect(ErrorPages.NOT_FOUND);
       }
 
       docCollection.forEach(it => (it.downloadLink = createDownloadLink(it.value.uploadedDocument)));

--- a/src/main/controllers/AttachmentController.ts
+++ b/src/main/controllers/AttachmentController.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
+import { ErrorPages } from '../definitions/constants';
 import { getDocId } from '../helper/ApiFormatter';
 import { getLogger } from '../logger';
 import { getCaseApi } from '../services/CaseService';
@@ -20,7 +21,7 @@ export default class AttachmentController {
 
     if (!docId) {
       logger.warn('no docId provided');
-      return res.redirect('/not-found');
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
 
     if (
@@ -37,11 +38,11 @@ export default class AttachmentController {
         res.status(200).send(Buffer.from(document?.data, 'binary'));
       } catch (err) {
         logger.error(err.message);
-        return res.redirect('/not-found');
+        return res.redirect(ErrorPages.NOT_FOUND);
       }
     } else {
       logger.warn('bad request parameter');
-      return res.redirect('/not-found');
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
   }
 }

--- a/src/main/controllers/CaseDocumentController.ts
+++ b/src/main/controllers/CaseDocumentController.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
+import { ErrorPages } from '../definitions/constants';
 import { getLogger } from '../logger';
 import { getUserCasesByLastModified } from '../services/CaseSelectionService';
 import { getCaseApi } from '../services/CaseService';
@@ -23,7 +24,7 @@ export default class CaseDocumentController {
     try {
       if (!req.params?.docId) {
         logger.info('bad request parameter');
-        return res.redirect('/not-found');
+        return res.redirect(ErrorPages.NOT_FOUND);
       }
 
       const docId = req.params.docId;
@@ -34,7 +35,7 @@ export default class CaseDocumentController {
       const details = allDocumentSets.find(doc => doc && doc.id === docId);
       if (!details) {
         logger.info('requested document not found in userCase');
-        return res.redirect('/not-found');
+        return res.redirect(ErrorPages.NOT_FOUND);
       }
 
       const document = await getCaseApi(req.session.user?.accessToken).getCaseDocument(docId);
@@ -54,7 +55,7 @@ export default class CaseDocumentController {
       setRespondentResponseHubLinkStatus(details, req, logger);
     } catch (err) {
       logger.error(err.message);
-      return res.redirect('/not-found');
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
   }
 }

--- a/src/main/controllers/ContactTheTribunalSelectedController.ts
+++ b/src/main/controllers/ContactTheTribunalSelectedController.ts
@@ -100,7 +100,7 @@ export default class ContactTheTribunalSelectedController {
           userCase.contactApplicationFile = fromApiFormatDocument(result.data);
         }
       } catch (error) {
-        logger.info(error);
+        logger.error(error);
         req.session.errors.push({ propertyName: 'contactApplicationFile', errorType: 'backEndError' });
       }
       return res.redirect(returnSafeRedirectUrl(req, redirectUrl, logger));

--- a/src/main/controllers/DescribeWhatHappenedController.ts
+++ b/src/main/controllers/DescribeWhatHappenedController.ts
@@ -118,7 +118,7 @@ export default class DescribeWhatHappenedController {
         req.session.userCase.claimSummaryFile = fromApiFormatDocument(result.data);
       }
     } catch (error) {
-      logger.info(error);
+      logger.error(error);
       req.session.errors = [{ propertyName: 'claimSummaryFileName', errorType: 'backEndError' }];
     }
   }

--- a/src/main/controllers/DownloadClaimController.ts
+++ b/src/main/controllers/DownloadClaimController.ts
@@ -14,7 +14,7 @@ export default class DownloadClaimController {
       res.setHeader('Content-Disposition', 'attachment; filename=submitted-claim.pdf');
       res.status(200).send(Buffer.from(pdf.data, 'binary'));
     } catch (error) {
-      logger.info(error.message);
+      logger.error(error.message);
       res.redirect('not-found');
     }
   }

--- a/src/main/controllers/GeneralCorrespondenceNotificationDetailsController.ts
+++ b/src/main/controllers/GeneralCorrespondenceNotificationDetailsController.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
-import { PageUrls, TranslationKeys } from '../definitions/constants';
+import { ErrorPages, PageUrls, TranslationKeys } from '../definitions/constants';
 import { FormContent } from '../definitions/form';
 import { HubLinkStatus } from '../definitions/hub';
 import { AnyRecord } from '../definitions/util-types';
@@ -24,7 +24,7 @@ export default class GeneralCorrespondenceNotificationDetailsController {
         selectedCorrespondence.value.notificationState = HubLinkStatus.VIEWED;
         await updateSendNotificationState(req, logger);
       } catch (error) {
-        logger.info(error.message);
+        logger.error(error.message);
       }
     }
     req.session.documentDownloadPage = PageUrls.GENERAL_CORRESPONDENCE_NOTIFICATION_DETAILS;
@@ -36,7 +36,7 @@ export default class GeneralCorrespondenceNotificationDetailsController {
           await populateDocumentMetadata(it.value.uploadedDocument, req.session.user?.accessToken);
         } catch (err) {
           logger.error(err.message);
-          res.redirect('/not-found');
+          res.redirect(ErrorPages.NOT_FOUND);
         }
       }
     }

--- a/src/main/controllers/HearingDocumentUploadController.ts
+++ b/src/main/controllers/HearingDocumentUploadController.ts
@@ -83,7 +83,7 @@ export default class HearingDocumentUploadController {
           userCase.hearingDocument = fromApiFormatDocument(result.data);
         }
       } catch (error) {
-        logger.info(error);
+        logger.error(error);
         req.session.errors.push({ propertyName: 'hearingDocument', errorType: 'backEndError' });
         return res.redirect(pageUrl);
       }

--- a/src/main/controllers/JudgmentDetailsController.ts
+++ b/src/main/controllers/JudgmentDetailsController.ts
@@ -104,7 +104,7 @@ export default class JudgmentDetailsController {
         try {
           await updateJudgmentNotificationState(selectedJudgment, req, logger);
         } catch (error) {
-          logger.info(error.message);
+          logger.error(error.message);
         }
       }
 

--- a/src/main/controllers/RespondToApplicationController.ts
+++ b/src/main/controllers/RespondToApplicationController.ts
@@ -4,7 +4,7 @@ import { Form } from '../components/form/form';
 import { isFieldFilledIn } from '../components/form/validator';
 import { AppRequest } from '../definitions/appRequest';
 import { YesOrNo } from '../definitions/case';
-import { PageUrls, Rule92Types, TranslationKeys } from '../definitions/constants';
+import { ErrorPages, PageUrls, Rule92Types, TranslationKeys } from '../definitions/constants';
 import { FormContent, FormFields } from '../definitions/form';
 import { AnyRecord } from '../definitions/util-types';
 import { getLogger } from '../logger';
@@ -103,7 +103,7 @@ export default class RespondToApplicationController {
         await populateDocumentMetadata(document, req.session.user?.accessToken);
       } catch (err) {
         logger.error(err.message);
-        return res.redirect('/not-found');
+        return res.redirect(ErrorPages.NOT_FOUND);
       }
     }
     const downloadLink = createDownloadLink(document);

--- a/src/main/controllers/RespondentApplicationsController.ts
+++ b/src/main/controllers/RespondentApplicationsController.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
-import { TranslationKeys } from '../definitions/constants';
+import { ErrorPages, TranslationKeys } from '../definitions/constants';
 import { FormContent } from '../definitions/form';
 import { AnyRecord } from '../definitions/util-types';
 import { fromApiFormat } from '../helper/ApiFormatter';
@@ -47,7 +47,7 @@ export default class RespondentApplicationsController {
       });
     } catch (error) {
       logger.error(error.message);
-      return res.redirect('/not-found');
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
   };
 }

--- a/src/main/controllers/RespondentSupportingMaterialController.ts
+++ b/src/main/controllers/RespondentSupportingMaterialController.ts
@@ -101,7 +101,7 @@ export default class RespondentSupportingMaterialController {
           userCase.supportingMaterialFile = fromApiFormatDocument(result.data);
         }
       } catch (error) {
-        logger.info(error);
+        logger.error(error);
         req.session.errors.push({ propertyName: 'supportingMaterialFile', errorType: 'backEndError' });
       }
       return res.redirect(returnSafeRedirectUrl(req, supportingMaterialUrl, logger));

--- a/src/main/controllers/SubmitBundlesHearingDocsCYAController.ts
+++ b/src/main/controllers/SubmitBundlesHearingDocsCYAController.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
-import { PageUrls } from '../definitions/constants';
+import { ErrorPages, PageUrls } from '../definitions/constants';
 import { getLogger } from '../logger';
 
 import { clearBundlesFields, submitBundlesHearingDocs } from './helpers/CaseHelpers';
@@ -15,7 +15,8 @@ export default class SubmitBundlesHearingDocsController {
       await submitBundlesHearingDocs(req, logger);
       clearBundlesFields(userCase);
     } catch (error) {
-      logger.info(error.message);
+      logger.error(error.message);
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
     return res.redirect(PageUrls.BUNDLES_COMPLETED);
   };

--- a/src/main/controllers/SubmitClaimController.ts
+++ b/src/main/controllers/SubmitClaimController.ts
@@ -16,7 +16,7 @@ export default class SubmitCaseController {
       req.session.userCase = fromApiFormat(submittedClaim.data);
       req.session.errors = [];
     } catch (error) {
-      logger.info(error.message);
+      logger.error(error.message);
       req.session.errors = [{ errorType: 'api', propertyName: 'hiddenErrorField' }];
       return res.redirect(PageUrls.CHECK_ANSWERS);
     }

--- a/src/main/controllers/SubmitRespondentController.ts
+++ b/src/main/controllers/SubmitRespondentController.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
 import { YesOrNo } from '../definitions/case';
-import { PageUrls } from '../definitions/constants';
+import { ErrorPages, PageUrls } from '../definitions/constants';
 import { getLogger } from '../logger';
 
 import { clearTseFields, handleUpdateHubLinksStatuses, respondToApplication } from './helpers/CaseHelpers';
@@ -19,7 +19,8 @@ export default class SubmitRespondentController {
       userCase.rule92state = userCase.copyToOtherPartyYesOrNo && userCase.copyToOtherPartyYesOrNo === YesOrNo.YES;
       clearTseFields(req.session?.userCase);
     } catch (error) {
-      logger.info(error.message);
+      logger.error(error.message);
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
     return res.redirect(PageUrls.RESPOND_TO_APPLICATION_COMPLETE + getLanguageParam(req.url));
   };

--- a/src/main/controllers/SubmitTribunalCYAController.ts
+++ b/src/main/controllers/SubmitTribunalCYAController.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
 import { YesOrNo } from '../definitions/case';
-import { PageUrls } from '../definitions/constants';
+import { ErrorPages, PageUrls } from '../definitions/constants';
 import { HubLinkNames, HubLinkStatus } from '../definitions/hub';
 import { getLogger } from '../logger';
 
@@ -20,7 +20,8 @@ export default class SubmitTseController {
       userCase.rule92state = userCase.copyToOtherPartyYesOrNo && userCase.copyToOtherPartyYesOrNo === YesOrNo.YES;
       clearTseFields(userCase);
     } catch (error) {
-      logger.info(error.message);
+      logger.error(error.message);
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
     return res.redirect(PageUrls.APPLICATION_COMPLETE);
   };

--- a/src/main/controllers/TribunalOrderOrRequestDetailsController.ts
+++ b/src/main/controllers/TribunalOrderOrRequestDetailsController.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
-import { Applicant, PageUrls, Parties, ResponseRequired, TranslationKeys } from '../definitions/constants';
+import { Applicant, ErrorPages, PageUrls, Parties, ResponseRequired, TranslationKeys } from '../definitions/constants';
 import { FormContent } from '../definitions/form';
 import { AnyRecord } from '../definitions/util-types';
 import { getLogger } from '../logger';
@@ -24,7 +24,7 @@ export default class TribunalOrderOrRequestDetailsController {
     try {
       await updateSendNotificationState(req, logger);
     } catch (error) {
-      logger.info(error.message);
+      logger.error(error.message);
     }
 
     const redirectUrl =
@@ -42,7 +42,7 @@ export default class TribunalOrderOrRequestDetailsController {
       );
     } catch (err) {
       logger.error(err.message);
-      res.redirect('/not-found');
+      res.redirect(ErrorPages.NOT_FOUND);
     }
 
     const translations: AnyRecord = {

--- a/src/main/controllers/TribunalRespondToOrderController.ts
+++ b/src/main/controllers/TribunalRespondToOrderController.ts
@@ -103,7 +103,7 @@ export default class TribunalRespondToOrderController {
     try {
       await updateSendNotificationState(req, logger);
     } catch (error) {
-      logger.info(error.message);
+      logger.error(error.message);
     }
 
     res.render(TranslationKeys.TRIBUNAL_RESPOND_TO_ORDER, {

--- a/src/main/controllers/TribunalResponseSubmitController.ts
+++ b/src/main/controllers/TribunalResponseSubmitController.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
 import { YesOrNo } from '../definitions/case';
-import { PageUrls } from '../definitions/constants';
+import { ErrorPages, PageUrls } from '../definitions/constants';
 import { HubLinkNames, HubLinkStatus } from '../definitions/hub';
 import { getLogger } from '../logger';
 
@@ -19,7 +19,8 @@ export default class TribunalResponseSubmitController {
       userCase.rule92state = userCase.copyToOtherPartyYesOrNo && userCase.copyToOtherPartyYesOrNo === YesOrNo.YES;
       clearTseFields(userCase);
     } catch (error) {
-      logger.info(error.message);
+      logger.error(error.message);
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
     return res.redirect(PageUrls.TRIBUNAL_RESPONSE_COMPLETED);
   };

--- a/src/main/controllers/citizen-hub/CitizenHubController.ts
+++ b/src/main/controllers/citizen-hub/CitizenHubController.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../../definitions/appRequest';
-import { PageUrls, TranslationKeys } from '../../definitions/constants';
+import { ErrorPages, PageUrls, TranslationKeys } from '../../definitions/constants';
 import {
   HubLinkNames,
   HubLinkStatus,
@@ -71,7 +71,7 @@ export default class CitizenHubController {
         );
       } catch (error) {
         logger.error(error.message);
-        return res.redirect('/not-found');
+        return res.redirect(ErrorPages.NOT_FOUND);
       }
     }
 

--- a/src/main/controllers/citizen-hub/CitizenHubDocumentController.ts
+++ b/src/main/controllers/citizen-hub/CitizenHubDocumentController.ts
@@ -1,7 +1,12 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../../definitions/appRequest';
-import { TranslationKeys, responseAcceptedDocTypes, responseRejectedDocTypes } from '../../definitions/constants';
+import {
+  ErrorPages,
+  TranslationKeys,
+  responseAcceptedDocTypes,
+  responseRejectedDocTypes,
+} from '../../definitions/constants';
 import { HubLinkNames, HubLinkStatus } from '../../definitions/hub';
 import { getLogger } from '../../logger';
 import { handleUpdateHubLinksStatuses } from '../helpers/CaseHelpers';
@@ -34,13 +39,13 @@ export default class CitizenHubDocumentController {
     const documents = mapParamToDoc(req?.params?.documentType);
     if (!documents) {
       logger.info('no documents found for ', req?.params?.documentType);
-      return res.redirect('/not-found');
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
     try {
       await getDocumentDetails(documents, req.session.user?.accessToken);
     } catch (err) {
       logger.error(err.message);
-      return res.redirect('/not-found');
+      return res.redirect(ErrorPages.NOT_FOUND);
     }
 
     let view = 'document-view';

--- a/src/test/unit/controller/SubmitTseController.test.ts
+++ b/src/test/unit/controller/SubmitTseController.test.ts
@@ -1,17 +1,18 @@
 import SubmitTseController from '../../../main/controllers/SubmitTribunalCYAController';
 import * as CaseHelper from '../../../main/controllers/helpers/CaseHelpers';
-import { PageUrls } from '../../../main/definitions/constants';
+import { ErrorPages, PageUrls } from '../../../main/definitions/constants';
 import { HubLinkNames, HubLinkStatus, HubLinksStatuses } from '../../../main/definitions/hub';
 import { mockRequest } from '../mocks/mockRequest';
 import { mockResponse } from '../mocks/mockResponse';
 
 describe('Submit tell something else Controller', () => {
-  it('should redirect to PageUrls.APPLICATION_COMPLETE', () => {
+  it('should redirect to PageUrls.APPLICATION_COMPLETE', async () => {
     const controller = new SubmitTseController();
     const response = mockResponse();
     const request = mockRequest({});
+    request.session.userCase.hubLinksStatuses = new HubLinksStatuses();
     request.url = PageUrls.APPLICATION_COMPLETE;
-    controller.get(request, response);
+    await controller.get(request, response);
     expect(response.redirect).toHaveBeenCalledWith(PageUrls.APPLICATION_COMPLETE);
   });
 
@@ -45,5 +46,14 @@ describe('Submit tell something else Controller', () => {
     expect(request.session.userCase.contactApplicationFile).toStrictEqual(undefined);
     expect(request.session.userCase.copyToOtherPartyYesOrNo).toStrictEqual(undefined);
     expect(request.session.userCase.copyToOtherPartyText).toStrictEqual(undefined);
+  });
+
+  it('should redirect to ErrorPages.NOT_FOUND', () => {
+    const controller = new SubmitTseController();
+    const response = mockResponse();
+    const request = mockRequest({});
+    request.url = PageUrls.APPLICATION_COMPLETE;
+    controller.get(request, response);
+    expect(response.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
   });
 });

--- a/src/test/unit/controller/TribunalResponseSubmitController.test.ts
+++ b/src/test/unit/controller/TribunalResponseSubmitController.test.ts
@@ -1,18 +1,19 @@
 import SubmitTseController from '../../../main/controllers/SubmitTribunalCYAController';
 import TribunalResponseSubmitController from '../../../main/controllers/TribunalResponseSubmitController';
 import * as CaseHelper from '../../../main/controllers/helpers/CaseHelpers';
-import { PageUrls } from '../../../main/definitions/constants';
+import { ErrorPages, PageUrls } from '../../../main/definitions/constants';
 import { HubLinkNames, HubLinkStatus, HubLinksStatuses } from '../../../main/definitions/hub';
 import { mockRequest } from '../mocks/mockRequest';
 import { mockResponse } from '../mocks/mockResponse';
 
 describe('Tribunal response submit controller', () => {
-  it('should redirect to PageUrls.APPLICATION_COMPLETE', () => {
+  it('should redirect to PageUrls.APPLICATION_COMPLETE', async () => {
     const controller = new TribunalResponseSubmitController();
     const response = mockResponse();
     const request = mockRequest({});
+    request.session.userCase.hubLinksStatuses = new HubLinksStatuses();
     request.url = PageUrls.TRIBUNAL_RESPONSE_COMPLETED;
-    controller.get(request, response);
+    await controller.get(request, response);
     expect(response.redirect).toHaveBeenCalledWith(PageUrls.TRIBUNAL_RESPONSE_COMPLETED);
   });
 
@@ -46,5 +47,14 @@ describe('Tribunal response submit controller', () => {
     expect(request.session.userCase.contactApplicationFile).toStrictEqual(undefined);
     expect(request.session.userCase.copyToOtherPartyYesOrNo).toStrictEqual(undefined);
     expect(request.session.userCase.copyToOtherPartyText).toStrictEqual(undefined);
+  });
+
+  it('should redirect to ErrorPages.NOT_FOUND', () => {
+    const controller = new TribunalResponseSubmitController();
+    const response = mockResponse();
+    const request = mockRequest({});
+    request.url = PageUrls.TRIBUNAL_RESPONSE_COMPLETED;
+    controller.get(request, response);
+    expect(response.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
   });
 });


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/RET-4334

### Change description

- Updated from '/not-found' to ErrorPages.NOT_FOUND
- Updated from logger.info to logger.error within catch block
- Added res.redirect(ErrorPages.NOT_FOUND) in catch block before redirect to COMPLETED page

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
