### PR TITLE
Danny Pipeline Optimisations 2 - Remove ALL puppeteer-installed browser from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ USER hmcts
 # ---- Build image ----
 
 FROM base as build
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn install && yarn build:prod
+RUN PUPPETEER_SKIP_DOWNLOAD=true yarn install && yarn build:prod
 
 # ---- Runtime image ----
 FROM base as runtime


### PR DESCRIPTION
Previously only removed Chromium, but makes sense to chuck other ones too!
Saved ~60s locally, we'll see about upstream!