### PR TITLE
 DTSPO-24173 ZAP security scanner alert filtering fix

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -64,10 +64,10 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withNightlyPipeline(type, product, component) {
     loadVaultSecrets(secrets)
     enableFortifyScan('et-aat')
-    enableSecurityScan(
-           urlExclusions: urlExclusions,
-           alertFilters: alertFilters
-    )
+//    enableSecurityScan(
+//           urlExclusions: urlExclusions,
+//           alertFilters: alertFilters
+//    )
 
     env.TEST_URL = params.TEST_URL
     env.RUNNING_ENV = params.ENVIRONMENT

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -25,12 +25,44 @@ parameters([
           name: 'ALERT_FILTERS',
           defaultValue:
             "-config globalalertfilter.filters.filter\\(0\\).ruleid=10055 " +
-            "-config globalalertfilter.filters.filter\\(0\\).newrisk=0 " +
+            "-config globalalertfilter.filters.filter\\(0\\).newrisk=-1 " +
             "-config globalalertfilter.filters.filter\\(0\\).enabled=true " +
 
             "-config globalalertfilter.filters.filter\\(1\\).ruleid=90027 " +
-            "-config globalalertfilter.filters.filter\\(1\\).newrisk=0 " +
-            "-config globalalertfilter.filters.filter\\(1\\).enabled=true "
+            "-config globalalertfilter.filters.filter\\(1\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(1\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(2\\).ruleid=10029 " +
+            "-config globalalertfilter.filters.filter\\(2\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(2\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(3\\).ruleid=10058 " +
+            "-config globalalertfilter.filters.filter\\(3\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(3\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(4\\).ruleid=10027 " +
+            "-config globalalertfilter.filters.filter\\(4\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(4\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(5\\).ruleid=10109 " +
+            "-config globalalertfilter.filters.filter\\(5\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(5\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(6\\).ruleid=10049 " +
+            "-config globalalertfilter.filters.filter\\(6\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(6\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(7\\).ruleid=10112 " +
+            "-config globalalertfilter.filters.filter\\(7\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(7\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(8\\).ruleid=10104 " +
+            "-config globalalertfilter.filters.filter\\(8\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(8\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(9\\).ruleid=10031 " +
+            "-config globalalertfilter.filters.filter\\(9\\).newrisk=-1 " +
+            "-config globalalertfilter.filters.filter\\(9\\).enabled=true "
         ),
         string(name: 'CUSTOM_COOKIES')
     ])
@@ -64,10 +96,10 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withNightlyPipeline(type, product, component) {
     loadVaultSecrets(secrets)
     enableFortifyScan('et-aat')
-//    enableSecurityScan(
-//           urlExclusions: urlExclusions,
-//           alertFilters: alertFilters
-//    )
+    enableSecurityScan(
+           urlExclusions: urlExclusions,
+           alertFilters: alertFilters
+    )
 
     env.TEST_URL = params.TEST_URL
     env.RUNNING_ENV = params.ENVIRONMENT

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -4,9 +4,34 @@ properties([
 // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
 pipelineTriggers([cron('H 8 * * 1-5')]),
 parameters([
-        string(name: 'TEST_URL', defaultValue: 'https://et-sya.aat.platform.hmcts.net', description: 'The URL you want to run tests against'),
-        string(name: 'ZAP_URL_EXCLUSIONS', defaultValue: "-config globalexcludeurl.url_list.url\\(1\\).regex='.*/assets.*' -config globalexcludeurl.url_list.url\\(2\\).regex='.*/cookies.*' -config globalexcludeurl.url_list.url\\(3\\).regex='.*/main.[a-fA-F0-9]{20}.js' -config globalexcludeurl.url_list.url\\(4\\).regex='.*/main.[a-fA-F0-9]{20}.css' -config globalexcludeurl.url_list.url\\(5\\).regex='.*/sitemap.xml(\\?lng=en)?' -config globalexcludeurl.url_list.url\\(6\\).regex='.*/robots.txt' -config globalexcludeurl.url_list.url\\(7\\).regex='.*/accessibility.*' -config rules.cookie.ignorelist=_ga,_gid,_gat,dtCookie,dtLatC,dtPC,dtSa,rxVisitor,rxvt,i18next,et-sya-session"),
-        string(name: 'ALERT_FILTERS', defaultValue: "-config globalalertfilter.filters.filter\\(0\\).ruleid=90027 -config globalalertfilter.filters.filter\\(0\\).newrisk=0"),
+        string(
+          name: 'TEST_URL',
+          defaultValue: 'https://et-sya.aat.platform.hmcts.net',
+          description: 'The URL you want to run tests against'
+        ),
+        string(
+          name: 'ZAP_URL_EXCLUSIONS',
+          defaultValue:
+            "-config globalexcludeurl.url_list.url\\(1\\).regex='.*/assets.*' " +
+            "-config globalexcludeurl.url_list.url\\(2\\).regex='.*/cookies.*' " +
+            "-config globalexcludeurl.url_list.url\\(3\\).regex='.*/main.[a-fA-F0-9]{20}.js' " +
+            "-config globalexcludeurl.url_list.url\\(4\\).regex='.*/main.[a-fA-F0-9]{20}.css' " +
+            "-config globalexcludeurl.url_list.url\\(5\\).regex='.*/sitemap.xml(\\?lng=en)?' " +
+            "-config globalexcludeurl.url_list.url\\(6\\).regex='.*/robots.txt' " +
+            "-config globalexcludeurl.url_list.url\\(7\\).regex='.*/accessibility.*' " +
+            "-config rules.cookie.ignorelist=_ga,_gid,_gat,dtCookie,dtLatC,dtPC,dtSa,rxVisitor,rxvt,i18next,et-sya-session"
+        ),
+        string(
+          name: 'ALERT_FILTERS',
+          defaultValue:
+            "-config globalalertfilter.filters.filter\\(0\\).ruleid=10055 " +
+            "-config globalalertfilter.filters.filter\\(0\\).newrisk=0 " +
+            "-config globalalertfilter.filters.filter\\(0\\).enabled=true " +
+
+            "-config globalalertfilter.filters.filter\\(1\\).ruleid=90027 " +
+            "-config globalalertfilter.filters.filter\\(1\\).newrisk=0 " +
+            "-config globalalertfilter.filters.filter\\(1\\).enabled=true "
+        ),
         string(name: 'CUSTOM_COOKIES')
     ])
 ])


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/DTSPO-24173

### Change description

Change the CLI parameters passed into the ZAP scanner so that existing Medium and Low alerts are reported as Informational and therefore do not fail the build.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```