### PR TITLE
Use the app insights connection string rather than depreciated instrumentation key

### DIFF
--- a/charts/et-sya/Chart.yaml
+++ b/charts/et-sya/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for et-sya App
 name: et-sya
 home: https://github.com/hmcts/et-sya-frontend
-version: 0.0.48
+version: 0.0.49
 dependencies:
   - name: nodejs
     version: 3.2.0

--- a/charts/et-sya/values.aat.template.yaml
+++ b/charts/et-sya/values.aat.template.yaml
@@ -10,7 +10,7 @@ nodejs:
     et:
       resourceGroup: et
       secrets:
-        - AppInsightsInstrumentationKey
+        - app-insights-connection-string
         - idam-secret
         - redis-access-key
         - os-places-token

--- a/charts/et-sya/values.preview.template.yaml
+++ b/charts/et-sya/values.preview.template.yaml
@@ -8,7 +8,7 @@ nodejs:
     et:
       resourceGroup: et
       secrets:
-        - AppInsightsInstrumentationKey
+        - app-insights-connection-string
         - idam-secret
         - redis-access-key
         - os-places-token

--- a/charts/et-sya/values.yaml
+++ b/charts/et-sya/values.yaml
@@ -8,7 +8,7 @@ nodejs:
     et:
       resourceGroup: et
       secrets:
-        - AppInsightsInstrumentationKey
+        - app-insights-connection-string
         - idam-secret
         - redis-access-key
         - os-places-token

--- a/config/default.json
+++ b/config/default.json
@@ -5,7 +5,7 @@
     "referrerPolicy": "origin"
   },
   "appInsights": {
-    "instrumentationKey": false,
+    "connectionString": false,
     "roleName": "et-sya"
   },
   "featureFlags": {

--- a/src/main/modules/appinsights/index.ts
+++ b/src/main/modules/appinsights/index.ts
@@ -4,9 +4,9 @@ const appInsights = require('applicationinsights');
 
 export class AppInsights {
   enable(): void {
-    if (config.get('appInsights.instrumentationKey')) {
-      appInsights.setup(config.get('appInsights.instrumentationKey')).setSendLiveMetrics(true).start();
-
+    const connectionString = config.get('appInsights.connectionString');
+    if (connectionString) {
+      appInsights.setup(connectionString).setSendLiveMetrics(true).start();
       appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] =
         config.get('appInsights.roleName');
       appInsights.defaultClient.trackTrace({

--- a/src/main/modules/properties-volume/index.ts
+++ b/src/main/modules/properties-volume/index.ts
@@ -8,7 +8,7 @@ export class PropertiesVolume {
     if (server.locals.ENV !== 'development' && server.locals.ENV !== 'test') {
       propertiesVolume.addTo(config);
 
-      this.setSecret('secrets.et.AppInsightsInstrumentationKey', 'appInsights.instrumentationKey');
+      this.setSecret('secrets.et.app-insights-connection-string', 'appInsights.connectionString');
       this.setSecret('secrets.et.idam-secret', 'services.idam.clientSecret');
       this.setSecret('secrets.et.redis-access-key', 'session.redis.key');
       this.setSecret('secrets.et.redis-access-key', 'session.secret');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7626,8 +7626,8 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-prettier@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "eslint-plugin-prettier@npm:4.2.1"
+  version: 4.2.5
+  resolution: "eslint-plugin-prettier@npm:4.2.5"
   dependencies:
     prettier-linter-helpers: ^1.0.0
   peerDependencies:
@@ -7636,7 +7636,7 @@ __metadata:
   peerDependenciesMeta:
     eslint-config-prettier:
       optional: true
-  checksum: b9e839d2334ad8ec7a5589c5cb0f219bded260839a857d7a486997f9870e95106aa59b8756ff3f37202085ebab658de382b0267cae44c3a7f0eb0bcc03a4f6d6
+  checksum: 22c29ba685f18516e3b1595e062849ccc108996a759da6067ff5d876519a5f81c8ba92c0c5623a1c62b593d417619ba44ab3b6ec1450ca753c078fd92970b883
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

### JIRA link
[RET-3427](https://tools.hmcts.net/jira/browse/RET-3427)
### Change description

Updated App insights Variables to use connection string rather than Instrumentation key (depreciated).
Checked key is in key vault on all environments.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
