### PR TITLE
fix: move per-request Nunjucks globals to res.locals to prevent cross-request contamination

### DIFF
--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -115,7 +115,7 @@ export class Nunjucks {
           hint: i.hint && {
             html: this.env.globals.getContent.call(this, i.hint),
           },
-          divider: this.env.globals.currentUrl.includes('lng=cy') ? i.divider && 'neu' : i.divider && 'or',
+          divider: this.ctx.currentUrl?.includes('lng=cy') ? i.divider && 'neu' : i.divider && 'or',
           behaviour: i.exclusive && 'exclusive',
           conditional: ((): { html: string | undefined } => {
             let innerHtml = '';
@@ -139,20 +139,19 @@ export class Nunjucks {
     );
 
     app.use((req: AppRequest, res, next) => {
-      nunEnv.addGlobal('isLoggedIn', !!res.locals.isLoggedIn);
+      res.locals.isLoggedIn = !!res.locals.isLoggedIn;
       next();
     });
 
     app.use((req, res, next) => {
       res.locals.host = req.headers['x-forwarded-host'] || req.hostname;
       res.locals.pagePath = req.path;
-      nunEnv.addGlobal('currentUrl', req.url);
-      nunEnv.addGlobal('currentHost', req?.headers?.host?.toLowerCase());
-      nunEnv.addGlobal('dateToLocale', (dateToTransform: Date) => dateInLocale(dateToTransform, req.url));
-      nunEnv.addGlobal('dateTimeInLocale', (dateToTransform: Date) => dateTimeInLocale(dateToTransform, req.url));
-      nunEnv.addGlobal('dateStringToLocale', (dateToTransform: string) =>
-        datesStringToDateInLocale(dateToTransform, req.url)
-      );
+      res.locals.currentUrl = req.url;
+      res.locals.currentHost = req?.headers?.host?.toLowerCase();
+      res.locals.dateToLocale = (dateToTransform: Date) => dateInLocale(dateToTransform, req.url);
+      res.locals.dateTimeInLocale = (dateToTransform: Date) => dateTimeInLocale(dateToTransform, req.url);
+      res.locals.dateStringToLocale = (dateToTransform: string) =>
+        datesStringToDateInLocale(dateToTransform, req.url);
       nunEnv.addGlobal('govukRebrand', true);
       next();
     });


### PR DESCRIPTION
## Jira
https://tools.hmcts.net/jira/browse/RET-6431

## Problem

The Nunjucks environment is a singleton shared across all concurrent requests. The previous implementation called `nunEnv.addGlobal()` inside per-request middleware, creating a race condition where concurrent requests could overwrite shared globals.

## Solution

Moved all per-request values to `res.locals` and fixed optional chaining on currentUrl.

Co-Authored-By: Oz <oz-agent@warp.dev>