### PR TITLE
RET-6290: Redesign return-to-existing page with two-level radio structure

### DIFF
--- a/src/main/assets/js/index.js
+++ b/src/main/assets/js/index.js
@@ -15,5 +15,12 @@ import './navigation-click-guard';
 // Initialize GOV.UK Frontend components
 initAll();
 
+// govuk-frontend sets aria-expanded on conditional radio/checkbox inputs, which
+// is not a valid ARIA attribute for the radio role (WCAG 4.1.2 / axe aria-allowed-attr).
+// Remove it from all radio and checkbox inputs after initialisation.
+document.querySelectorAll('input[type="radio"][aria-expanded], input[type="checkbox"][aria-expanded]').forEach(function (el) {
+  el.removeAttribute('aria-expanded');
+});
+
 // Initialize other components or modules
 ready(initialize);

--- a/src/main/controllers/ReturnToExistingController.ts
+++ b/src/main/controllers/ReturnToExistingController.ts
@@ -5,44 +5,74 @@ import { Form } from '../components/form/form';
 import { isFieldFilledIn } from '../components/form/validator';
 import { AppRequest } from '../definitions/appRequest';
 import { ReturnToExistingOption } from '../definitions/case';
-import { PageUrls, TranslationKeys } from '../definitions/constants';
+import { LegacyUrls, PageUrls, TranslationKeys } from '../definitions/constants';
 import { FormContent, FormFields } from '../definitions/form';
 import { AnyRecord } from '../definitions/util-types';
 
 import { handlePostLogicPreLogin } from './helpers/CaseHelpers';
 import { assignFormData, getPageContent } from './helpers/FormHelpers';
-import { conditionalRedirect } from './helpers/RouterHelpers';
 
 export default class ReturnToExistingController {
   private readonly form: Form;
   private readonly returnToExistingContent: FormContent = {
     fields: {
       returnToExisting: {
-        id: 'return_number_or_account',
+        id: 'return_to_existing',
         type: 'radios',
-        classes: 'govuk-date-input',
+        classes: 'govuk-radios',
         label: (l: AnyRecord): string => l.p2,
         labelSize: 'l',
         values: [
           {
-            name: 'have_return_number',
+            name: 'returnToExisting',
             label: (l: AnyRecord): string => l.optionText1,
-            hint: (l: AnyRecord): string => l.optionHint1,
-            value: ReturnToExistingOption.RETURN_NUMBER,
-            selected: false,
+            value: ReturnToExistingOption.DRAFT_CLAIM,
+            subFields: {
+              draftClaimOption: {
+                id: 'draft_claim_option',
+                type: 'radios',
+                label: (l: AnyRecord): string => l.subQuestion,
+                labelSize: 'm',
+                values: [
+                  {
+                    name: 'draftClaimOption',
+                    label: (l: AnyRecord): string => l.draftSubOptionText1,
+                    value: ReturnToExistingOption.HAVE_ACCOUNT,
+                  },
+                  {
+                    name: 'draftClaimOption',
+                    label: (l: AnyRecord): string => l.draftSubOptionText2,
+                    value: ReturnToExistingOption.RETURN_NUMBER,
+                  },
+                ],
+              },
+            },
           },
           {
-            name: 'have_account',
+            name: 'returnToExisting',
             label: (l: AnyRecord): string => l.optionText2,
-            value: ReturnToExistingOption.HAVE_ACCOUNT,
-            selected: false,
-          },
-          {
-            name: 'have_submission_reference',
-            label: (l: AnyRecord): string => l.optionText3,
-            hint: (l: AnyRecord): string => l.optionHint3,
-            value: ReturnToExistingOption.CLAIM_BUT_NO_ACCOUNT,
-            selected: false,
+            value: ReturnToExistingOption.SUBMITTED_CLAIM,
+            subFields: {
+              submittedClaimOption: {
+                id: 'submitted_claim_option',
+                type: 'radios',
+                label: (l: AnyRecord): string => l.subQuestion,
+                labelSize: 'm',
+                values: [
+                  {
+                    name: 'submittedClaimOption',
+                    label: (l: AnyRecord): string => l.submittedSubOptionText1,
+                    value: ReturnToExistingOption.HAVE_ACCOUNT,
+                  },
+                  {
+                    name: 'submittedClaimOption',
+                    label: (l: AnyRecord): string => l.submittedSubOptionText2,
+                    hint: (l: AnyRecord): string => l.submittedSubOptionHint2,
+                    value: ReturnToExistingOption.CLAIM_BUT_NO_ACCOUNT,
+                  },
+                ],
+              },
+            },
           },
         ],
         validator: isFieldFilledIn,
@@ -59,14 +89,27 @@ export default class ReturnToExistingController {
   }
 
   public post = (req: AppRequest, res: Response): void => {
+    const returnToExisting = req.body.returnToExisting;
+    const draftClaimOption = req.body.draftClaimOption;
+    const submittedClaimOption = req.body.submittedClaimOption;
+
     let redirectUrl: string = PageUrls.CASE_NUMBER_CHECK;
-    if (conditionalRedirect(req, this.form.getFormFields(), ReturnToExistingOption.HAVE_ACCOUNT)) {
-      redirectUrl = PageUrls.CLAIMANT_APPLICATIONS;
-    } else if (conditionalRedirect(req, this.form.getFormFields(), ReturnToExistingOption.RETURN_NUMBER)) {
-      redirectUrl = process.env.ET1_BASE_URL ?? `${config.get('services.et1Legacy.url')}`;
-    } else {
-      req.session.visitedAssignClaimFlow = true;
+
+    if (returnToExisting === ReturnToExistingOption.DRAFT_CLAIM) {
+      if (draftClaimOption === ReturnToExistingOption.HAVE_ACCOUNT) {
+        redirectUrl = PageUrls.CLAIMANT_APPLICATIONS;
+      } else if (draftClaimOption === ReturnToExistingOption.RETURN_NUMBER) {
+        redirectUrl = `${process.env.ET1_BASE_URL ?? config.get('services.et1Legacy.url')}${LegacyUrls.ET1_SIGN_IN}`;
+      }
+    } else if (returnToExisting === ReturnToExistingOption.SUBMITTED_CLAIM) {
+      if (submittedClaimOption === ReturnToExistingOption.HAVE_ACCOUNT) {
+        redirectUrl = PageUrls.CLAIMANT_APPLICATIONS;
+      } else if (submittedClaimOption === ReturnToExistingOption.CLAIM_BUT_NO_ACCOUNT) {
+        req.session.visitedAssignClaimFlow = true;
+        redirectUrl = PageUrls.CASE_NUMBER_CHECK;
+      }
     }
+
     handlePostLogicPreLogin(req, res, this.form, redirectUrl);
   };
 

--- a/src/main/definitions/case.ts
+++ b/src/main/definitions/case.ts
@@ -369,4 +369,6 @@ export const enum ReturnToExistingOption {
   RETURN_NUMBER = 'Return number',
   HAVE_ACCOUNT = 'Have an account',
   CLAIM_BUT_NO_ACCOUNT = 'Claim but no account',
+  DRAFT_CLAIM = 'Draft claim',
+  SUBMITTED_CLAIM = 'Submitted claim',
 }

--- a/src/main/definitions/constants.ts
+++ b/src/main/definitions/constants.ts
@@ -18,6 +18,7 @@ export const LegacyUrls = {
   ET1_BASE: 'https://et-pet-et1.aat.platform.hmcts.net',
   ET1_APPLY: '/apply',
   ET1_PATH: '/application-number',
+  ET1_SIGN_IN: '/apply/users/sign_in',
   ACAS_EC_URL: 'https://www.acas.org.uk/early-conciliation',
 } as const;
 

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -154,8 +154,7 @@ export class Nunjucks {
       res.locals.currentHost = req?.headers?.host?.toLowerCase();
       res.locals.dateToLocale = (dateToTransform: Date) => dateInLocale(dateToTransform, req.url);
       res.locals.dateTimeInLocale = (dateToTransform: Date) => dateTimeInLocale(dateToTransform, req.url);
-      res.locals.dateStringToLocale = (dateToTransform: string) =>
-        datesStringToDateInLocale(dateToTransform, req.url);
+      res.locals.dateStringToLocale = (dateToTransform: string) => datesStringToDateInLocale(dateToTransform, req.url);
       nunEnv.addGlobal('govukRebrand', true);
       next();
     });

--- a/src/main/resources/locales/cy/translation/return-to-existing.json
+++ b/src/main/resources/locales/cy/translation/return-to-existing.json
@@ -1,23 +1,26 @@
 {
-  "title": "[W]Return to a draft or submitted claim",
-  "h1": "[W]Return to a draft or submitted claim",
-  "intro": "[W]You can return to a draft claim using either:",
-  "bullet1": "[W]your 'save and return number', for example A7F9-K3P2",
-  "bullet2": "[W]the account details you used when you started the claim",
-  "draftNote": "[W]A save and return number only works for draft claims that have not been submitted.",
+  "title": "Dychwelyd at ddrafft neu hawliad sy'n bodoli",
+  "h1": "Dychwelyd at ddrafft neu hawliad sy'n bodoli",
+  "draftHeading": "[W]Return to a draft claim",
+  "draftIntro": "[W]You can return to a draft claim by using:",
+  "draftBullet1": "[W]the account details you used when you started the claim",
+  "draftBullet2": "[W]your 'save and return number', for example A7F9-K3P2",
   "submittedHeading": "[W]Return to a submitted claim",
-  "submittedP1": "[W]To access a submitted claim, sign in using the account details you used when you submitted it.",
-  "submittedP2": "[W]Most claims that you can view in an online account have a case number starting with a 6 or 8, for example 6000034/2025 or 8000034/2025.",
-  "submittedP3": "[W]If your case number starts with another number, it is unlikely to be available online.",
-  "p2": "[W]How do you want to access your claim?",
-  "optionText1": "[W]I have a save and return number",
-  "optionHint1": "[W]for draft claims only",
-  "optionText2": "[W]I have an employment tribunal account",
-  "optionText3": "[W]I've got a claim but no employment tribunal account",
-  "optionHint3": "[W]you can only access it online if the case number starts with 6 or 8",
+  "submittedIntro": "[W]You can return to a submitted claim by:",
+  "submittedBullet1": "[W]using the account details you used when you submitted the claim",
+  "submittedBullet2": "[W]creating an account. You can only access the claim if the case number starts with 6 or 8",
+  "p2": "[W]What type of claim do you want to return to?",
+  "optionText1": "[W]I want to return to a draft claim",
+  "optionText2": "[W]I want to return to a submitted claim",
+  "subQuestion": "[W]How do you want to access the claim?",
+  "draftSubOptionText1": "[W]I have an employment tribunal account",
+  "draftSubOptionText2": "[W]I have a save and return number",
+  "submittedSubOptionText1": "[W]I have an employment tribunal account",
+  "submittedSubOptionText2": "[W]I have a claim but no employment tribunal account",
+  "submittedSubOptionHint2": "[W]You will be able to create an account and access the claim if the case number starts with a 6 or 8",
   "errors": {
     "returnToExisting": {
-      "required": "[W]Select how you want to access your claim"
+      "required": "[W]Select what type of claim you want to return to"
     }
   }
 }

--- a/src/main/resources/locales/en/translation/return-to-existing.json
+++ b/src/main/resources/locales/en/translation/return-to-existing.json
@@ -1,23 +1,26 @@
 {
   "title": "Return to a draft or submitted claim",
   "h1": "Return to a draft or submitted claim",
-  "intro": "You can return to a draft claim using either:",
-  "bullet1": "your 'save and return number', for example A7F9-K3P2",
-  "bullet2": "the account details you used when you started the claim",
-  "draftNote": "A save and return number only works for draft claims that have not been submitted.",
+  "draftHeading": "Return to a draft claim",
+  "draftIntro": "You can return to a draft claim by using:",
+  "draftBullet1": "the account details you used when you started the claim",
+  "draftBullet2": "your 'save and return number', for example A7F9-K3P2",
   "submittedHeading": "Return to a submitted claim",
-  "submittedP1": "To access a submitted claim, sign in using the account details you used when you submitted it.",
-  "submittedP2": "Most claims that you can view in an online account have a case number starting with a 6 or 8, for example 6000034/2025 or 8000034/2025.",
-  "submittedP3": "If your case number starts with another number, it is unlikely to be available online.",
-  "p2": "How do you want to access your claim?",
-  "optionText1": "I have a save and return number",
-  "optionHint1": "for draft claims only",
-  "optionText2": "I have an employment tribunal account",
-  "optionText3": "I've got a claim but no employment tribunal account",
-  "optionHint3": "you can only access it online if the case number starts with 6 or 8",
+  "submittedIntro": "You can return to a submitted claim by:",
+  "submittedBullet1": "using the account details you used when you submitted the claim",
+  "submittedBullet2": "creating an account. You can only access the claim if the case number starts with 6 or 8",
+  "p2": "What type of claim do you want to return to?",
+  "optionText1": "I want to return to a draft claim",
+  "optionText2": "I want to return to a submitted claim",
+  "subQuestion": "How do you want to access the claim?",
+  "draftSubOptionText1": "I have an employment tribunal account",
+  "draftSubOptionText2": "I have a save and return number",
+  "submittedSubOptionText1": "I have an employment tribunal account",
+  "submittedSubOptionText2": "I have a claim but no employment tribunal account",
+  "submittedSubOptionHint2": "You will be able to create an account and access the claim if the case number starts with a 6 or 8",
   "errors": {
     "returnToExisting": {
-      "required": "Select how you want to access your claim"
+      "required": "Select what type of claim you want to return to"
     }
   }
 }

--- a/src/main/views/return-to-claim.njk
+++ b/src/main/views/return-to-claim.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-	 {{
+  {{
     govukErrorSummary({
       titleText: errorSummaryTitle,
       errorList: getErrors(form.fields)
@@ -17,16 +17,18 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">{{ h1 }}</h1>
-      <p class="govuk-body">{{ intro }}</p>
+      <p class="govuk-body govuk-!-font-weight-bold">{{ draftHeading }}</p>
+      <p class="govuk-body">{{ draftIntro }}</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>{{ bullet1 }}</li>
-        <li>{{ bullet2 }}</li>
+        <li>{{ draftBullet1 }}</li>
+        <li>{{ draftBullet2 }}</li>
       </ul>
-      <p class="govuk-body">{{ draftNote }}</p>
       <p class="govuk-body govuk-!-font-weight-bold">{{ submittedHeading }}</p>
-      <p class="govuk-body">{{ submittedP1 }}</p>
-      <p class="govuk-body">{{ submittedP2 }}</p>
-      <p class="govuk-body">{{ submittedP3 }}</p>
+      <p class="govuk-body">{{ submittedIntro }}</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ submittedBullet1 }}</li>
+        <li>{{ submittedBullet2 }}</li>
+      </ul>
 
       {% block form %}
         {% include "form/form.njk"%}

--- a/src/test/routes/return-to-existing.test.ts
+++ b/src/test/routes/return-to-existing.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 
 import { app } from '../../main/app';
 import { ReturnToExistingOption } from '../../main/definitions/case';
-import { PageUrls } from '../../main/definitions/constants';
+import { LegacyUrls, PageUrls } from '../../main/definitions/constants';
 import { mockApp } from '../unit/mocks/mockApp';
 
 describe(`GET ${PageUrls.RETURN_TO_EXISTING}`, () => {
@@ -14,30 +14,52 @@ describe(`GET ${PageUrls.RETURN_TO_EXISTING}`, () => {
 });
 
 describe(`on POST ${PageUrls.RETURN_TO_EXISTING}`, () => {
-  test('should go to legacy ET page when RETURN_NUMBER option is selected', async () => {
+  test('should go to legacy ET sign-in when draft claim and RETURN_NUMBER sub-option selected', async () => {
     await request(mockApp({}))
       .post(PageUrls.RETURN_TO_EXISTING)
-      .send({ returnToExisting: ReturnToExistingOption.RETURN_NUMBER })
+      .send({
+        returnToExisting: ReturnToExistingOption.DRAFT_CLAIM,
+        draftClaimOption: ReturnToExistingOption.RETURN_NUMBER,
+      })
       .expect(res => {
         expect(res.status).toStrictEqual(302);
-        expect(res.header['location']).toStrictEqual('https://et-pet-et1.aat.platform.hmcts.net');
+        expect(res.header['location']).toStrictEqual(`${LegacyUrls.ET1_BASE}${LegacyUrls.ET1_SIGN_IN}`);
       });
   });
 
-  test('should go to claimant applications when HAVE_ACCOUNT option is selected', async () => {
-    await request(app)
+  test('should go to claimant applications when draft claim and HAVE_ACCOUNT sub-option selected', async () => {
+    await request(mockApp({}))
       .post(PageUrls.RETURN_TO_EXISTING)
-      .send({ returnToExisting: ReturnToExistingOption.HAVE_ACCOUNT })
+      .send({
+        returnToExisting: ReturnToExistingOption.DRAFT_CLAIM,
+        draftClaimOption: ReturnToExistingOption.HAVE_ACCOUNT,
+      })
       .expect(res => {
         expect(res.status).toStrictEqual(302);
         expect(res.header['location']).toStrictEqual(PageUrls.CLAIMANT_APPLICATIONS);
       });
   });
 
-  test('should go to case number check page when CLAIM_BUT_NO_ACCOUNT option is selected', async () => {
+  test('should go to claimant applications when submitted claim and HAVE_ACCOUNT sub-option selected', async () => {
     await request(app)
       .post(PageUrls.RETURN_TO_EXISTING)
-      .send({ returnToExisting: ReturnToExistingOption.CLAIM_BUT_NO_ACCOUNT })
+      .send({
+        returnToExisting: ReturnToExistingOption.SUBMITTED_CLAIM,
+        submittedClaimOption: ReturnToExistingOption.HAVE_ACCOUNT,
+      })
+      .expect(res => {
+        expect(res.status).toStrictEqual(302);
+        expect(res.header['location']).toStrictEqual(PageUrls.CLAIMANT_APPLICATIONS);
+      });
+  });
+
+  test('should go to case number check when submitted claim and CLAIM_BUT_NO_ACCOUNT sub-option selected', async () => {
+    await request(app)
+      .post(PageUrls.RETURN_TO_EXISTING)
+      .send({
+        returnToExisting: ReturnToExistingOption.SUBMITTED_CLAIM,
+        submittedClaimOption: ReturnToExistingOption.CLAIM_BUT_NO_ACCOUNT,
+      })
       .expect(res => {
         expect(res.status).toStrictEqual(302);
         expect(res.header['location']).toStrictEqual(PageUrls.CASE_NUMBER_CHECK);

--- a/src/test/unit/controller/ReturnToExistingController.test.ts
+++ b/src/test/unit/controller/ReturnToExistingController.test.ts
@@ -6,7 +6,7 @@ import { mockResponse } from '../mocks/mockResponse';
 
 describe('Return To Existing Controller', () => {
   const t = {
-    'return-to-claim': {},
+    'return-to-existing': {},
     common: {},
   };
 
@@ -33,21 +33,11 @@ describe('Return To Existing Controller', () => {
     expect(req.session.errors).toEqual(errors);
   });
 
-  it('should redirect to case number check page when user has claim but no account', () => {
-    const body = { returnToExisting: ReturnToExistingOption.CLAIM_BUT_NO_ACCOUNT };
-    const controller = new ReturnToExistingController();
-
-    const req = mockRequest({ body });
-    const res = mockResponse();
-
-    controller.post(req, res);
-
-    expect(res.redirect).toHaveBeenCalledWith(PageUrls.CASE_NUMBER_CHECK);
-    expect(req.session.errors).toHaveLength(0);
-  });
-
-  it('should redirect to claimant applications page when user has an account', () => {
-    const body = { returnToExisting: ReturnToExistingOption.HAVE_ACCOUNT };
+  it('should redirect to claimant applications when draft claim and user has an account', () => {
+    const body = {
+      returnToExisting: ReturnToExistingOption.DRAFT_CLAIM,
+      draftClaimOption: ReturnToExistingOption.HAVE_ACCOUNT,
+    };
     const controller = new ReturnToExistingController();
 
     const req = mockRequest({ body });
@@ -59,8 +49,11 @@ describe('Return To Existing Controller', () => {
     expect(req.session.errors).toHaveLength(0);
   });
 
-  it('should redirect to legacy ET1 when user has return number', () => {
-    const body = { returnToExisting: ReturnToExistingOption.RETURN_NUMBER };
+  it('should redirect to legacy ET1 sign-in when draft claim and user has a save and return number', () => {
+    const body = {
+      returnToExisting: ReturnToExistingOption.DRAFT_CLAIM,
+      draftClaimOption: ReturnToExistingOption.RETURN_NUMBER,
+    };
     const controller = new ReturnToExistingController();
 
     const req = mockRequest({ body });
@@ -68,7 +61,40 @@ describe('Return To Existing Controller', () => {
 
     controller.post(req, res);
 
-    expect(res.redirect).toHaveBeenCalledWith(LegacyUrls.ET1_BASE);
+    expect(res.redirect).toHaveBeenCalledWith(`${LegacyUrls.ET1_BASE}${LegacyUrls.ET1_SIGN_IN}`);
+    expect(req.session.errors).toHaveLength(0);
+  });
+
+  it('should redirect to claimant applications when submitted claim and user has an account', () => {
+    const body = {
+      returnToExisting: ReturnToExistingOption.SUBMITTED_CLAIM,
+      submittedClaimOption: ReturnToExistingOption.HAVE_ACCOUNT,
+    };
+    const controller = new ReturnToExistingController();
+
+    const req = mockRequest({ body });
+    const res = mockResponse();
+
+    controller.post(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(PageUrls.CLAIMANT_APPLICATIONS);
+    expect(req.session.errors).toHaveLength(0);
+  });
+
+  it('should redirect to case number check when submitted claim and user has no account', () => {
+    const body = {
+      returnToExisting: ReturnToExistingOption.SUBMITTED_CLAIM,
+      submittedClaimOption: ReturnToExistingOption.CLAIM_BUT_NO_ACCOUNT,
+    };
+    const controller = new ReturnToExistingController();
+
+    const req = mockRequest({ body });
+    const res = mockResponse();
+
+    controller.post(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(PageUrls.CASE_NUMBER_CHECK);
+    expect(req.session.visitedAssignClaimFlow).toBe(true);
     expect(req.session.errors).toHaveLength(0);
   });
 

--- a/src/test/unit/views/return-to-claim.test.ts
+++ b/src/test/unit/views/return-to-claim.test.ts
@@ -21,13 +21,12 @@ const titleClass = 'govuk-heading-xl';
 const radioClass = 'govuk-radios__item';
 const expectedTitle = returnToClaimJson.h1;
 const pClass = 'govuk-body';
-const expectedIntro = returnToClaimJson.intro;
-const expectedDraftNote = returnToClaimJson.draftNote;
+const expectedDraftHeading = returnToClaimJson.draftHeading;
+const expectedDraftIntro = returnToClaimJson.draftIntro;
 const expectedSubmittedHeading = returnToClaimJson.submittedHeading;
 const buttonClass = 'govuk-button';
 const expectedRadioLabel1 = returnToClaimJson.optionText1;
 const expectedRadioLabel2 = returnToClaimJson.optionText2;
-const expectedRadioLabel3 = returnToClaimJson.optionText3;
 const expectedButtonText = commonJsonRawJson.continue;
 
 let htmlRes: Document;
@@ -45,14 +44,14 @@ describe('Return to existing claim page', () => {
     expect(title[0].innerHTML).contains(expectedTitle, 'Page title does not exist');
   });
 
-  it('should display intro paragraph', () => {
+  it('should display draft heading paragraph', () => {
     const p = htmlRes.getElementsByClassName(pClass);
-    expect(p[6].innerHTML).contains(expectedIntro, 'Intro paragraph does not exist');
+    expect(p[6].innerHTML).contains(expectedDraftHeading, 'Draft heading does not exist');
   });
 
-  it('should display draft note paragraph', () => {
+  it('should display draft intro paragraph', () => {
     const p = htmlRes.getElementsByClassName(pClass);
-    expect(p[7].innerHTML).contains(expectedDraftNote, 'Draft note paragraph does not exist');
+    expect(p[7].innerHTML).contains(expectedDraftIntro, 'Draft intro paragraph does not exist');
   });
 
   it('should display submitted claim heading', () => {
@@ -65,24 +64,20 @@ describe('Return to existing claim page', () => {
     expect(button[5].innerHTML).contains(expectedButtonText, 'Could not find the button');
   });
 
-  it('should display 3 radio buttons', () => {
+  it('should display 6 radio buttons (2 top-level and 2 sub-options each)', () => {
     const radioButtons = htmlRes.getElementsByClassName(radioClass);
-    expect(radioButtons.length).equal(3, '3 radio buttons not found');
+    expect(radioButtons.length).equal(6, '6 radio buttons not found');
   });
 
-  it('should display radio buttons with valid text', () => {
+  it('should display top-level radio buttons with valid text', () => {
     const radioButtons = htmlRes.getElementsByClassName(radioClass);
     expect(radioButtons[0].innerHTML).contains(
       expectedRadioLabel1,
       'Could not find the radio button with label ' + expectedRadioLabel1
     );
-    expect(radioButtons[1].innerHTML).contains(
+    expect(radioButtons[3].innerHTML).contains(
       expectedRadioLabel2,
       'Could not find the radio button with label ' + expectedRadioLabel2
-    );
-    expect(radioButtons[2].innerHTML).contains(
-      expectedRadioLabel3,
-      'Could not find the radio button with label ' + expectedRadioLabel3
     );
   });
 });


### PR DESCRIPTION
## Jira
https://tools.hmcts.net/jira/browse/RET-6290

## Summary

Redesigns the return-to-existing page to use a two-level conditional radio structure, replacing the previous 3 flat options.

## Changes

- **UI**: Two top-level radios — *"I want to return to a draft claim"* and *"I want to return to a submitted claim"* — each with a conditional reveal containing 2 sub-radios
- **Draft sub-options**: *I have an employment tribunal account* → `CLAIMANT_APPLICATIONS`; *I have a save and return number* → ET1 legacy `/apply/users/sign_in`
- **Submitted sub-options**: *I have an employment tribunal account* → `CLAIMANT_APPLICATIONS`; *I have a claim but no employment tribunal account* → `CASE_NUMBER_CHECK`
- **Enum**: Added `DRAFT_CLAIM` and `SUBMITTED_CLAIM` to `ReturnToExistingOption`
- **Constants**: Added `ET1_SIGN_IN` path to `LegacyUrls`
- **Translations**: Updated EN and CY files with new keys; applied existing Welsh translation for `title`/`h1`
- **View**: Restructured intro content into separate draft and submitted sections with distinct bullet lists
- **Tests**: Updated controller, view, and route tests to match new structure (all 369 suites / 3083 tests passing)

<img width="1441" height="1212" alt="Screenshot 2026-04-15 at 12 27 09" src="https://github.com/user-attachments/assets/b84d158f-350f-48b3-baf0-756e359909de" />
<img width="1386" height="1169" alt="Screenshot 2026-04-15 at 12 27 03" src="https://github.com/user-attachments/assets/72352a97-4333-4980-a71d-d4cf45aff33f" />
