### PR TITLE
RET-6470: Add HMCTS Access login URL support via /o/authorize endpoint

### DIFF
--- a/charts/et-sya/Chart.yaml
+++ b/charts/et-sya/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for et-sya App
 name: et-sya
 home: https://github.com/hmcts/et-sya-frontend
-version: 0.0.55
+version: 0.0.56
 dependencies:
   - name: nodejs
     version: 3.2.1

--- a/charts/et-sya/values.yaml
+++ b/charts/et-sya/values.yaml
@@ -17,6 +17,8 @@ nodejs:
         - csrf-token-secret
   environment:
     IDAM_WEB_URL: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/login'
+    IDAM_WEB_URL_HMCTS_ACCESS: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/o/authorize'
+    HMCTS_ACCESS: 'false'
     IDAM_API_URL: 'https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/o/token'
     REDIS_HOST: 'et-session-storage-{{ .Values.global.environment }}.redis.cache.windows.net'
     ET_SYA_API_HOST: 'http://et-sya-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'

--- a/config/default.json
+++ b/config/default.json
@@ -26,6 +26,8 @@
     "idam": {
       "clientID": "et-sya",
       "authorizationURL": "https://idam-web-public.aat.platform.hmcts.net/login",
+      "hmctsAccessURL": "https://idam-web-public.aat.platform.hmcts.net/o/authorize",
+      "hmctsAccess": false,
       "clientSecret": "TO BE PICKED UP FROM ENV",
       "tokenURL": "https://idam-api.aat.platform.hmcts.net/o/token"
     },

--- a/src/main/auth/index.ts
+++ b/src/main/auth/index.ts
@@ -12,7 +12,10 @@ export const getRedirectUrl = (
   languageParam: string
 ): string => {
   const clientID: string = process.env.IDAM_CLIENT_ID ?? config.get('services.idam.clientID');
-  const loginUrl: string = process.env.IDAM_WEB_URL ?? config.get('services.idam.authorizationURL');
+  const hmctsAccess: boolean = (process.env.HMCTS_ACCESS ?? String(config.get('services.idam.hmctsAccess'))) === 'true';
+  const loginUrl: string = hmctsAccess
+    ? process.env.IDAM_WEB_URL_HMCTS_ACCESS ?? config.get('services.idam.hmctsAccessURL')
+    : process.env.IDAM_WEB_URL ?? config.get('services.idam.authorizationURL');
   const callbackUrl = encodeURI(serviceUrl + callbackUrlPage);
   return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}&state=${guid}&ui_locales=${languageParam}`;
 };

--- a/src/test/unit/auth/auth.test.ts
+++ b/src/test/unit/auth/auth.test.ts
@@ -12,13 +12,25 @@ const token =
 const citizenToken =
   'eyJ0eXAiOiJKV1QiLCJraWQiOiIxZXIwV1J3Z0lPVEFGb2pFNHJDL2ZiZUt1M0k9IiwiYWxnIjoiUlMyNTYifQ.eyJhdF9oYXNoIjoiajIyZzNtZ1BEUkpIMDRDU0laTnBJZyIsInN1YiI6ImNpdGl6ZW4tdXNlckB0ZXN0LmNvLnVrIiwiYXVkaXRUcmFja2luZ0lkIjoiZjM0ZTZjOWMtZmRmYi00NDRmLWFjNjYtZWQxZmQ2NjAxZWIzLTQ2MjU0MDEwIiwicm9sZXMiOlsiY2l0aXplbiIsImNhc2V3b3JrZXItZW1wbG95bWVudC1hcGkiLCJjYXNld29ya2VyLWVtcGxveW1lbnQiLCJjYXNld29ya2VyLWVtcGxveW1lbnQtZW5nbGFuZHdhbGVzIiwiY2FzZXdvcmtlciJdLCJpc3MiOiJodHRwczovL2Zvcmdlcm9jay1hbS5zZXJ2aWNlLmNvcmUtY29tcHV0ZS1pZGFtLWFhdDIuaW50ZXJuYWw6ODQ0My9vcGVuYW0vb2F1dGgyL3JlYWxtcy9yb290L3JlYWxtcy9obWN0cyIsInRva2VuTmFtZSI6ImlkX3Rva2VuIiwiZ2l2ZW5fbmFtZSI6IkNpdGl6ZW4iLCJhdWQiOiJobWN0cyIsInVpZCI6ImE0Mzk2YjEwLTY5MjgtNDcxMS1hM2JhLTg5ZmNmNmFkYjc3OSIsImF6cCI6ImhtY3RzIiwiYXV0aF90aW1lIjoxNjUzNDkyMzkzLCJuYW1lIjoiQ2l0aXplbiBUZXN0ZXIiLCJyZWFsbSI6Ii9obWN0cyIsImV4cCI6MTY1MzQ5NTk5MywidG9rZW5UeXBlIjoiSldUVG9rZW4iLCJpYXQiOjE2NTM0OTIzOTMsImZhbWlseV9uYW1lIjoiVGVzdGVyIn0.KTfxz0oMqSqwRkcPczZISwp5hOP_RLcopqu9mOIdARg1TiZhzEnueo8_ppSrzb6YZRLmhO65K-hsqjBX1gE_oSN_975i5mfE3gBd1B_vCvEtS3YFLc_ReLiSTRW9Y0AelPzKOMqW2E0yFU_1IdCBrq3-rtQK2e1sAD8vVOIRF9ooih9mi3vUnD6kevDj099u_aE7qy_ueClt37CWhQ1achOxb11EeVYjv4K48TG1TxiBtIJx2H2b5lZayQuAPd8Jn4SEXXLCvhbt5K61L7NFZh0UiNfRjySwfIPX9MIovUPsGvnK4zJ6a4fqJU0SIl6v5wN5WMXp0u1YUzx7fzIoww';
 const loginUrl = process.env.IDAM_WEB_URL ?? config.get('services.idam.authorizationURL');
+const hmctsAccessLoginUrl = process.env.IDAM_WEB_URL_HMCTS_ACCESS ?? config.get('services.idam.hmctsAccessURL');
 const guid = '4e3cac74-d8cf-4de9-ad20-cf6248ba99aa';
 const languageParam = languages.ENGLISH;
 
 describe('getRedirectUrl', () => {
+  afterEach(() => {
+    delete process.env.HMCTS_ACCESS;
+  });
+
   test('should create a valid URL to redirect to the login screen', () => {
     expect(getRedirectUrl('http://localhost', AuthUrls.CALLBACK, guid, languageParam)).toBe(
       `${loginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${guid}&ui_locales=${languageParam}`
+    );
+  });
+
+  test('should use HMCTS Access authorize URL when HMCTS_ACCESS is true', () => {
+    process.env.HMCTS_ACCESS = 'true';
+    expect(getRedirectUrl('http://localhost', AuthUrls.CALLBACK, guid, languageParam)).toBe(
+      `${hmctsAccessLoginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${guid}&ui_locales=${languageParam}`
     );
   });
 });


### PR DESCRIPTION
## RET-6470

https://tools.hmcts.net/jira/browse/RET-6470

## Changes

- Added `IDAM_WEB_URL_HMCTS_ACCESS` environment variable in the Helm chart (`values.yaml`) pointing to the `/o/authorize` endpoint
- Added `HMCTS_ACCESS` feature flag (default `false`) to the Helm chart and `config/default.json`
- Updated `src/main/auth/index.ts` to select the login URL based on `HMCTS_ACCESS` — when `true`, uses the new `/o/authorize` endpoint; when `false` (default), retains the existing `/login` endpoint
- Updated unit tests to cover both `HMCTS_ACCESS = false` and `HMCTS_ACCESS = true` paths