### PR TITLE
Point AAT SYA frontend to et-ccd-callbacks

### DIFF
--- a/charts/et-sya/values.aat.template.yaml
+++ b/charts/et-sya/values.aat.template.yaml
@@ -5,6 +5,7 @@ nodejs:
   devmemoryLimits: 1024Mi
   devmemoryRequests: 512Mi
   environment:
+    ET_SYA_API_HOST: http://et-cos-aat.service.core-compute-aat.internal
     OAUTH_CLIENT_REDIRECT: https://${SERVICE_FQDN}/oauth2/callback
   keyVaults:
     et:


### PR DESCRIPTION
## Summary
- point the AAT-only `ET_SYA_API_HOST` override at `et-cos-aat.service.core-compute-aat.internal`
- keep the shared/default host unchanged so non-AAT environments still use `et-sya-api`

## Testing
- not run (Helm values change only)