### PR TITLE
fix: guard against undefined session values causing pod crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.5.0",
     "typescript": "5.1.6",
-    "uuid": "^11.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.11.2",

--- a/src/main/controllers/AttachmentController.ts
+++ b/src/main/controllers/AttachmentController.ts
@@ -29,6 +29,11 @@ export default class AttachmentController {
       return res.redirect('/not-found');
     }
 
+    if (!userCase) {
+      logger.warn('no userCase found in session');
+      return res.redirect('/not-found');
+    }
+
     if (
       docId === getDocId(userCase.contactApplicationFile?.document_url) ||
       docId === getDocId(userCase.supportingMaterialFile?.document_url) ||

--- a/src/main/controllers/BundlesDocsForHearingCYAController.ts
+++ b/src/main/controllers/BundlesDocsForHearingCYAController.ts
@@ -30,7 +30,7 @@ export default class BundlesDocsForHearingCYAController {
 
     const downloadLink = createDownloadLinkForHearingDoc(userCase?.hearingDocument);
     const foundHearing = userCase.hearingCollection?.find(hearing => hearing.id === userCase.hearingDocumentsAreFor);
-    const formattedSelectedHearing = createLabelForHearing(foundHearing);
+    const formattedSelectedHearing = foundHearing ? createLabelForHearing(foundHearing) : undefined;
     userCase.formattedSelectedHearing = formattedSelectedHearing;
     const bundlesEnabled = await getFlagValue(FEATURE_FLAGS.BUNDLES, null);
 

--- a/src/main/controllers/RespondToApplicationController.ts
+++ b/src/main/controllers/RespondToApplicationController.ts
@@ -71,6 +71,11 @@ export default class RespondToApplicationController {
 
     const selectedApplication = req.session.userCase.selectedGenericTseApplication;
 
+    if (!selectedApplication) {
+      logger.warn(`no selectedGenericTseApplication found in session for caseId: ${req.session.userCase?.id}`);
+      return res.redirect('/not-found');
+    }
+
     const applicationType = translations[selectedApplication.value.type];
     const respondByDate = getApplicationRespondByDate(selectedApplication, translations);
     const applicationDate = datesStringToDateInLocale(selectedApplication.value.date, req.url);

--- a/src/main/controllers/helpers/FormHelpers.ts
+++ b/src/main/controllers/helpers/FormHelpers.ts
@@ -110,6 +110,9 @@ const formatDate = (rawDate: Date): string =>
   }).format(new Date(rawDate));
 
 export const createLabelForHearing = (hearing: HearingModel): string => {
+  if (!hearing?.value) {
+    return;
+  }
   // filter out hearings with dates in the past
   // hearings can have multiple dates set so
   // reduce to find the earliest date set for that particular hearing

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -63,7 +63,7 @@ export class Oidc {
     });
 
     app.get(AuthUrls.CALLBACK, (req: AppRequest, res: Response, next: NextFunction) => {
-      idamCallbackHandler(req, res, next, serviceUrl(res));
+      idamCallbackHandler(req, res, next, serviceUrl(res)).catch(next);
     });
 
     app.use(async (req: AppRequest, res: Response, next: NextFunction) => {
@@ -98,9 +98,14 @@ export const idamCallbackHandler = async (
 ): Promise<void> => {
   const redisClient = req.app.locals?.redisClient;
   if (typeof req.query.code === 'string' && typeof req.query.state === 'string') {
-    // eslint-disable-next-line prettier/prettier
-    req.session.user = await getUserDetails(serviceUrl, req.query.code, AuthUrls.CALLBACK);
-    req.session.save();
+    try {
+      // eslint-disable-next-line prettier/prettier
+      req.session.user = await getUserDetails(serviceUrl, req.query.code, AuthUrls.CALLBACK);
+      req.session.save();
+    } catch (err) {
+      logger.error('Failed to retrieve user details from IDAM: ' + err.message);
+      return res.redirect(AuthUrls.LOGIN);
+    }
   } else {
     return res.redirect(AuthUrls.LOGIN);
   }

--- a/yarn-audit-known-issues
+++ b/yarn-audit-known-issues
@@ -1,1 +1,0 @@
-{"value":"uuid","children":{"ID":1116970,"Issue":"uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided","URL":"https://github.com/advisories/GHSA-w5hq-g745-h8pq","Severity":"moderate","Vulnerable Versions":"<14.0.0","Tree Versions":["11.1.0"],"Dependents":["et-sya@workspace:."]}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9468,7 +9468,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tsconfig-paths: "npm:^4.2.0"
     typescript: "npm:5.1.6"
-    uuid: "npm:^11.0.0"
+    uuid: "npm:^11.1.1"
     webdriverio: "npm:^8.8.6"
     webpack: "npm:^5.80.0"
     webpack-cli: "npm:^5.0.2"
@@ -18798,12 +18798,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:11.1.0, uuid@npm:^11.0.0":
+"uuid@npm:11.1.0":
   version: 11.1.0
   resolution: "uuid@npm:11.1.0"
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10/16411d3dc12a08d6691616c09a75e66a7f900ba1beef6628a76fe0602f82fae2ee537b564d0b7bc95c24f58d059ca9b58c75a1e806118efb50e17822ff00ddd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes multiple `TypeError: Cannot read properties of undefined` crashes causing pod restarts in prod-00 and prod-01.

## Changes

### `AttachmentController.ts`
- Added explicit `!userCase` guard — redirects to `/not-found` if `userCase` is missing from the session

### `RespondToApplicationController.ts`
- Added `!selectedApplication` guard — redirects to `/not-found` if `selectedGenericTseApplication` is not set in the session, logging the `caseId` for traceability

### `BundlesDocsForHearingCYAController.ts`
- Guard `createLabelForHearing` call when `hearingCollection.find()` returns `undefined`

### `FormHelpers.ts`
- Added early-return guard in `createLabelForHearing` for undefined `hearing` or `hearing.value`

### `oidc/index.ts`
- Wrapped `getUserDetails` in try-catch to handle IDAM 400 errors gracefully (redirect to login instead of crashing)
- Added `.catch(next)` to the CALLBACK route to prevent unhandled promise rejections from crashing the Node.js process

## Root Cause

All crashes were unhandled `TypeError`s thrown synchronously or via unhandled promise rejections inside Express route handlers, which Node.js escalates to process crashes.