### PR TITLE
HMCTS-AccessScopes: add scope parameter to IDAM redirect URL

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -4,6 +4,7 @@
     "idam": {
       "clientID": "et-sya",
       "authorizationURL": "http://localhost:5062/login",
+      "hmctsAccessURL": "http://localhost:5062/o/authorize",
       "clientSecret": "test1234",
       "tokenURL": "http://localhost:5062/o/token"
     },

--- a/src/main/auth/index.ts
+++ b/src/main/auth/index.ts
@@ -17,7 +17,9 @@ export const getRedirectUrl = (
     ? process.env.IDAM_WEB_URL_HMCTS_ACCESS ?? config.get('services.idam.hmctsAccessURL')
     : process.env.IDAM_WEB_URL ?? config.get('services.idam.authorizationURL');
   const callbackUrl = encodeURI(serviceUrl + callbackUrlPage);
-  return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}&state=${guid}&ui_locales=${languageParam}`;
+  return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}&state=${guid}&ui_locales=${languageParam}&scope=${encodeURIComponent(
+    'openid profile roles'
+  )}`;
 };
 
 export const getUserDetails = async (

--- a/src/test/unit/auth/auth.test.ts
+++ b/src/test/unit/auth/auth.test.ts
@@ -23,14 +23,14 @@ describe('getRedirectUrl', () => {
 
   test('should create a valid URL to redirect to the login screen', () => {
     expect(getRedirectUrl('http://localhost', AuthUrls.CALLBACK, guid, languageParam)).toBe(
-      `${loginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${guid}&ui_locales=${languageParam}`
+      `${loginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${guid}&ui_locales=${languageParam}&scope=openid%20profile%20roles`
     );
   });
 
   test('should use HMCTS Access authorize URL when HMCTS_ACCESS is true', () => {
     process.env.HMCTS_ACCESS = 'true';
     expect(getRedirectUrl('http://localhost', AuthUrls.CALLBACK, guid, languageParam)).toBe(
-      `${hmctsAccessLoginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${guid}&ui_locales=${languageParam}`
+      `${hmctsAccessLoginUrl}?client_id=et-sya&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${guid}&ui_locales=${languageParam}&scope=openid%20profile%20roles`
     );
   });
 });


### PR DESCRIPTION
## Summary

Adds `openid profile roles` scope to the IDAM authorization redirect URL and updates the auth tests to match.

### Changes
- `src/main/auth/index.ts` — appends `&scope=openid%20profile%20roles` to the login redirect URL
- `config/development.json` — related config update
- `src/test/unit/auth/auth.test.ts` — updated expected URLs to include the scope parameter