### PR TITLE
RET-6560: Add IDAM end session URL for proper logout flow

### DIFF
--- a/charts/et-sya/Chart.yaml
+++ b/charts/et-sya/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for et-sya App
 name: et-sya
 home: https://github.com/hmcts/et-sya-frontend
-version: 0.0.56
+version: 0.0.57
 dependencies:
   - name: nodejs
     version: 3.2.1

--- a/charts/et-sya/values.yaml
+++ b/charts/et-sya/values.yaml
@@ -18,6 +18,7 @@ nodejs:
   environment:
     IDAM_WEB_URL: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/login'
     IDAM_WEB_URL_HMCTS_ACCESS: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/o/authorize'
+    IDAM_END_SESSION_URL: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/o/endSession'
     HMCTS_ACCESS: 'false'
     IDAM_API_URL: 'https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/o/token'
     REDIS_HOST: 'et-session-storage-{{ .Values.global.environment }}.redis.cache.windows.net'

--- a/config/default.json
+++ b/config/default.json
@@ -29,7 +29,8 @@
       "hmctsAccessURL": "https://idam-web-public.aat.platform.hmcts.net/o/authorize",
       "hmctsAccess": false,
       "clientSecret": "TO BE PICKED UP FROM ENV",
-      "tokenURL": "https://idam-api.aat.platform.hmcts.net/o/token"
+      "tokenURL": "https://idam-api.aat.platform.hmcts.net/o/token",
+      "endSessionURL": "https://idam-web-public.aat.platform.hmcts.net/o/endSession"
     },
     "addressLookup": {
       "url": "https://api.os.uk/search/places/v1/postcode",

--- a/config/development.json
+++ b/config/development.json
@@ -6,7 +6,8 @@
       "authorizationURL": "http://localhost:5062/login",
       "hmctsAccessURL": "http://localhost:5062/o/authorize",
       "clientSecret": "test1234",
-      "tokenURL": "http://localhost:5062/o/token"
+      "tokenURL": "http://localhost:5062/o/token",
+      "endSessionURL": "http://localhost:5062/o/endSession"
     },
     "addressLookup": {
       "url": "https://api.os.uk/search/places/v1/postcode",

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -1,7 +1,5 @@
-import * as url from 'url';
-
 import config from 'config';
-import { Application, NextFunction, Request, Response } from 'express';
+import { Application, NextFunction, Response } from 'express';
 
 import { getRedirectUrl, getUserDetails } from '../../auth';
 import { AppRequest } from '../../definitions/appRequest';
@@ -28,6 +26,7 @@ export class Oidc {
   public enableFor(app: Application): void {
     const port = app.locals.developmentMode ? `:${config.get('port')}` : '';
     const serviceUrl = (res: Response): string => `${HTTPS_PROTOCOL}${res.locals.host}${port}`;
+    const idamSignOutUrl: string = process.env.IDAM_END_SESSION_URL ?? config.get('services.idam.endSessionURL');
 
     app.get(AuthUrls.LOGIN, (req: AppRequest, res) => {
       let stateParam;
@@ -49,16 +48,19 @@ export class Oidc {
       res.redirect(getRedirectUrl(serviceUrl(res), AuthUrls.CALLBACK, stateParam, languageParam));
     });
 
-    app.get(AuthUrls.LOGOUT, (req, res) => {
+    app.get(AuthUrls.LOGOUT, (req: AppRequest, res: Response) => {
+      // serviceUrl(res) resolves to the homepage of the service and is used as the post_logout_redirect_uri for IDAM,
+      // so that after logout, user is redirected to the homepage
+      const params = new URLSearchParams({
+        id_token_hint: req.session.user?.accessToken,
+        post_logout_redirect_uri: serviceUrl(res),
+      });
+
       req.session.destroy(err => {
         if (err) {
           logger.error('Error destroying session');
         }
-        if (req.query.redirectUrl) {
-          return handleRedirectUrl(req, res);
-        } else {
-          return res.redirect(PageUrls.HOME);
-        }
+        res.redirect(idamSignOutUrl + '?' + params.toString());
       });
     });
 
@@ -79,15 +81,6 @@ export class Oidc {
       }
     });
   }
-}
-
-function handleRedirectUrl(req: Request, res: Response) {
-  const parsedUrl = url.parse(req.query.redirectUrl as string);
-  if (parsedUrl.host !== req.headers.host && (req.query.redirectUrl as string) !== '/?lng=en') {
-    logger.error('Unauthorised External Redirect Attempted to %s', parsedUrl.href);
-    return res.redirect(PageUrls.HOME);
-  }
-  return res.redirect(req.query.redirectUrl as string);
 }
 
 export const idamCallbackHandler = async (

--- a/src/test/unit/modules/oidc/oidc.test.ts
+++ b/src/test/unit/modules/oidc/oidc.test.ts
@@ -1,0 +1,155 @@
+import config from 'config';
+import { Application, Response } from 'express';
+
+import { AppRequest } from '../../../../main/definitions/appRequest';
+import { AuthUrls, HTTPS_PROTOCOL, PageUrls } from '../../../../main/definitions/constants';
+import { Oidc } from '../../../../main/modules/oidc';
+
+const mockLoggerError = jest.fn();
+jest.mock('@hmcts/nodejs-logging', () => {
+  const mockError = jest.fn();
+  return {
+    __mockError: mockError,
+    Logger: {
+      getLogger: () => ({
+        error: mockError,
+        info: jest.fn(),
+        warn: jest.fn(),
+      }),
+    },
+  };
+});
+
+const { __mockError: mockLoggerErrorRef } = jest.requireMock('@hmcts/nodejs-logging') as {
+  __mockError: jest.Mock;
+};
+
+const idamSignOutUrl: string = process.env.IDAM_END_SESSION_URL ?? config.get('services.idam.endSessionURL');
+
+describe('Oidc logout handler', () => {
+  let logoutHandler: (req: AppRequest, res: Response) => void;
+  const mockHost = 'localhost:3002';
+
+  beforeAll(() => {
+    const handlers = new Map<string, (req: AppRequest, res: Response) => void>();
+    const mockApp = {
+      locals: { developmentMode: false },
+      get: (path: string, handler: (req: AppRequest, res: Response) => void) => handlers.set(path, handler),
+      use: jest.fn(),
+    } as unknown as Application;
+
+    new Oidc().enableFor(mockApp);
+    logoutHandler = handlers.get(AuthUrls.LOGOUT);
+  });
+
+  let mockRes: Partial<Response>;
+
+  beforeEach(() => {
+    mockLoggerErrorRef.mockClear();
+    mockLoggerError.mockClear();
+    mockRes = {
+      redirect: jest.fn(),
+      locals: { host: mockHost },
+    } as unknown as Partial<Response>;
+  });
+
+  test('destroys the session on logout', () => {
+    const mockDestroy = jest.fn(cb => cb(null));
+    const mockReq = {
+      session: { user: { accessToken: 'testToken' }, destroy: mockDestroy },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('redirects to IDAM end session URL with id_token_hint and post_logout_redirect_uri', () => {
+    const accessToken = 'testAccessToken';
+    const mockReq = {
+      session: {
+        user: { accessToken },
+        destroy: jest.fn(cb => cb(null)),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    const expectedParams = new URLSearchParams({
+      id_token_hint: accessToken,
+      post_logout_redirect_uri: `${HTTPS_PROTOCOL}${mockHost}`,
+    });
+    expect(mockRes.redirect).toHaveBeenCalledWith(`${idamSignOutUrl}?${expectedParams.toString()}`);
+  });
+
+  test('does not redirect to home page on logout', () => {
+    const mockReq = {
+      session: {
+        user: { accessToken: 'testToken' },
+        destroy: jest.fn(cb => cb(null)),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockRes.redirect).not.toHaveBeenCalledWith(PageUrls.HOME);
+  });
+
+  test('still redirects to IDAM end session URL when session destroy errors', () => {
+    const accessToken = 'testAccessToken';
+    const mockReq = {
+      session: {
+        user: { accessToken },
+        destroy: jest.fn(cb => cb(new Error('session destroy error'))),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockRes.redirect).toHaveBeenCalled();
+    const redirectUrl = (mockRes.redirect as jest.Mock).mock.calls[0][0] as string;
+    expect(redirectUrl.startsWith(idamSignOutUrl)).toBe(true);
+  });
+
+  test('logs an error when session destroy fails', () => {
+    const mockReq = {
+      session: {
+        user: { accessToken: 'testToken' },
+        destroy: jest.fn(cb => cb(new Error('session destroy error'))),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockLoggerErrorRef).toHaveBeenCalledWith('Error destroying session');
+  });
+
+  test('does not log an error when session destroy succeeds', () => {
+    const mockReq = {
+      session: {
+        user: { accessToken: 'testToken' },
+        destroy: jest.fn(cb => cb(null)),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockLoggerErrorRef).not.toHaveBeenCalled();
+  });
+
+  test('still redirects to IDAM end session URL when no user is in the session', () => {
+    const mockReq = {
+      session: {
+        user: undefined,
+        destroy: jest.fn(cb => cb(null)),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockRes.redirect).toHaveBeenCalled();
+    const redirectUrl = (mockRes.redirect as jest.Mock).mock.calls[0][0] as string;
+    expect(redirectUrl).toContain(idamSignOutUrl);
+    expect(redirectUrl).toContain(`post_logout_redirect_uri=${encodeURIComponent(`${HTTPS_PROTOCOL}${mockHost}`)}`);
+  });
+});


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-6560

## Summary

Updates the OIDC logout handler to perform a proper IDAM end-session redirect rather than redirecting back to the home page.

## Changes

### `src/main/modules/oidc/index.ts`
- Reads `IDAM_END_SESSION_URL` env var (falling back to `services.idam.endSessionURL` config) on module initialisation
- On `GET /logout`, builds a `URLSearchParams` object containing:
  - `id_token_hint` — the user's IDAM access token (from `req.session.user?.accessToken`)
  - `post_logout_redirect_uri` — the service base URL
- Destroys the session and redirects to the IDAM end-session URL with those params appended, replacing the previous redirect to `PageUrls.HOME`
- Removed the now-unused `handleRedirectUrl` helper and its `url` import

### `config/default.json` / `config/development.json`
- Added `services.idam.endSessionURL` config entry

### `charts/et-sya/values.yaml`
- Added `IDAM_END_SESSION_URL` environment variable

### `src/test/unit/modules/oidc/oidc.test.ts` *(new file)*
- Unit tests covering the logout handler:
  - Session is destroyed on logout
  - Redirects to the IDAM end-session URL with correct `id_token_hint` and `post_logout_redirect_uri` query params
  - Does **not** redirect to `PageUrls.HOME`
  - Still redirects to IDAM end-session URL when `session.destroy` errors
  - Logs error when session destroy fails; does not log when it succeeds
  - Handles missing `req.session.user` gracefully via optional chaining