### PR TITLE
fix: RET-5527 cache hashed static assets with long maxAge

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -53,7 +53,7 @@ app.use(favicon(path.join(__dirname, '/public/assets/images/favicon.ico')));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, 'public'), { maxAge: '1y', immutable: true }));
 app.use((req, res, next) => {
   res.setHeader('Cache-Control', 'no-cache, max-age=0, must-revalidate, no-store');
   next();


### PR DESCRIPTION

## Jira

[RET-5527](https://tools.hmcts.net/jira/browse/RET-5527)

## Description

Set `maxAge: '1y'` and `immutable: true` on `express.static` to prevent the browser from making a network request for hashed static assets (e.g. `main.*.css`) on every page navigation.

Previously, `express.static` was called without cache options, defaulting to `maxAge: 0`. This caused the browser to make a conditional GET request (ETag check) for static assets on every page load.

Since webpack includes a content hash in filenames (e.g. `main.38d16c435119d3f24daf.css`), it is safe to cache these files indefinitely — the URL changes automatically when content changes on deploy.

## Change

```ts
// Before
app.use(express.static(path.join(__dirname, 'public')));

// After
app.use(express.static(path.join(__dirname, 'public'), { maxAge: '1y', immutable: true }));
```