### PR TITLE
Group Claims - File validation

### DIFF
--- a/src/main/components/form/group-claims-validator.ts
+++ b/src/main/components/form/group-claims-validator.ts
@@ -42,16 +42,12 @@ function validateClaimantsAddresses(claimant: AdditionalClaimant, additionalClai
   }
 }
 
-export const validateAdditionalClaimants = (req: AppRequest): FormError[] => {
+export const validateAdditionalClaimants = (additionalClaimants: AdditionalClaimant[]): FormError[] => {
   const additionalClaimantErrors: FormError[] = [];
-  const claimants = req.session?.userCase?.additionalClaimants;
-  const additionalClaimantCount = claimants?.length || 0;
 
   // Validate structural data if claimants exist
-  if (claimants && Array.isArray(claimants)) {
-    logger.info(`Validating ${additionalClaimantCount} additional claimant(s).`);
-
-    for (const claimant of claimants) {
+  if (additionalClaimants && Array.isArray(additionalClaimants)) {
+    for (const claimant of additionalClaimants) {
       // Validate Name Fields
       validateClaimantsNames(claimant, additionalClaimantErrors);
 
@@ -80,7 +76,7 @@ export const validateGroupClaimsCheckDetails = (req?: AppRequest, userCase?: Rec
 
   const hasAdditionalClaimants =
     (Array.isArray(additionalClaimants) && additionalClaimants.length > 0) || Boolean(additionalClaimantSpreadsheet);
-  const claimantErrors = req ? validateAdditionalClaimants(req) : [];
+  const claimantErrors = additionalClaimants ? validateAdditionalClaimants(additionalClaimants) : [];
   const hasLeadClaimantSelection = leadClaimant === YesOrNo.YES || leadClaimant === YesOrNo.NO;
   const hasClaimantErrors = claimantErrors.length > 0;
 

--- a/src/main/controllers/helpers/multiples/AdditionalClaimantFileUploadService.ts
+++ b/src/main/controllers/helpers/multiples/AdditionalClaimantFileUploadService.ts
@@ -4,18 +4,79 @@ import { AppRequest } from '../../../definitions/appRequest';
 import { Document } from '../../../definitions/case';
 import { fromApiFormatDocument } from '../../../helper/ApiFormatter';
 import { getLogger } from '../../../logger';
-import { validateSpreadsheetData } from '../../../validators/multiples/additionalClaimantUploadValidator';
+import {
+  FieldErrorType,
+  validateSpreadsheetData,
+} from '../../../validators/multiples/additionalClaimantUploadValidator';
 import { handleUploadDocument } from '../CaseHelpers';
 import { getAdditionalClaimantSpreadsheetError } from '../ErrorHelpers';
 
 const logger = getLogger('AdditionalClaimantFileUploadService');
 const DEFAULT_MAX_ROWS_FOR_UPLOAD = 50;
+const MAX_ROWS_PER_ERROR_TYPE_BEFORE_SUMMARY_MESSAGE = 10;
+const MULTIPLE_ERROR_TYPES_SUMMARY_MIN_TYPES = 3;
+const SPREADSHEET_PROPERTY_NAME = 'additionalClaimantSpreadsheetName';
+type SpreadsheetValidationResult = Awaited<ReturnType<typeof validateSpreadsheetData>>;
+type SpreadsheetValidationStatus = SpreadsheetValidationResult['status'];
+type NonOkSpreadsheetValidationStatus = Exclude<SpreadsheetValidationStatus, 'ok'>;
 
 export type ValidationError = {
   propertyName: string;
   errorType: string;
   fieldName?: string;
-} | null;
+  fieldName2?: string;
+};
+
+const ERROR_TYPE_ORDER: FieldErrorType[] = [
+  'missingMandatory',
+  'invalidTitle',
+  'invalidFirstName',
+  'invalidLastName',
+  'invalidAddressLine1',
+  'invalidAddressLine2',
+  'invalidTown',
+  'invalidCountry',
+  'invalidDob',
+  'invalidEmail',
+  'invalidPostcode',
+];
+
+const TOO_MANY_ROWS_ERROR_TYPE_MAP: Record<FieldErrorType, string> = {
+  missingMandatory: 'missingMandatoryTooManyRows',
+  invalidTitle: 'invalidFieldTooManyRows',
+  invalidFirstName: 'invalidFieldTooManyRows',
+  invalidLastName: 'invalidFieldTooManyRows',
+  invalidAddressLine1: 'invalidFieldTooManyRows',
+  invalidAddressLine2: 'invalidFieldTooManyRows',
+  invalidTown: 'invalidFieldTooManyRows',
+  invalidCountry: 'invalidFieldTooManyRows',
+  invalidDob: 'invalidFieldTooManyRows',
+  invalidEmail: 'invalidFieldTooManyRows',
+  invalidPostcode: 'invalidFieldTooManyRows',
+};
+const MULTIPLE_ERROR_TYPES_SUMMARY_ERROR_TYPE = 'multipleErrorTypesSummary';
+const GENERIC_INVALID_FIELD_SINGLE_ROW_ERROR_TYPE = 'invalidFieldSingleRow';
+const GENERIC_INVALID_FIELD_MULTIPLE_ROWS_ERROR_TYPE = 'invalidFieldMultipleRows';
+type InvalidFieldErrorType = Exclude<FieldErrorType, 'missingMandatory'>;
+const INVALID_FIELD_LABEL_KEY_MAP: Record<InvalidFieldErrorType, string> = {
+  invalidTitle: 'title',
+  invalidFirstName: 'firstName',
+  invalidLastName: 'lastName',
+  invalidAddressLine1: 'addressLine1',
+  invalidAddressLine2: 'addressLine2',
+  invalidTown: 'townOrCity',
+  invalidCountry: 'country',
+  invalidDob: 'dateOfBirth',
+  invalidEmail: 'emailAddress',
+  invalidPostcode: 'postcode',
+};
+
+// Statuses returned by validateSpreadsheetData that short-circuit with a single, fixed error.
+const SIMPLE_STATUS_ERROR_TYPE: Record<NonOkSpreadsheetValidationStatus, string> = {
+  fileEmpty: 'fileEmpty',
+  noDataRows: 'noDataRows',
+  dataRowsExceedsMax: 'dataRowsExceedsMax',
+};
 
 export class AdditionalClaimantSpreadsheetService {
   public getMaxDataRowsForUpload(): number {
@@ -47,35 +108,23 @@ export class AdditionalClaimantSpreadsheetService {
     return null;
   }
 
-  public async validateSpreadsheet(req: AppRequest): Promise<ValidationError> {
+  /**
+   * Validates every row in the spreadsheet and returns one ValidationError
+   * per distinct problem found (e.g. missing mandatory data, invalid DOB,
+   * invalid postcode), each carrying its own list of affected row numbers.
+   */
+  public async validateSpreadsheet(req: AppRequest): Promise<ValidationError[]> {
+    if (!req.file) {
+      return [this.buildSimpleError('required')];
+    }
+
     const maxDataRowsForUpload = this.getMaxDataRowsForUpload();
     const result = await validateSpreadsheetData(req.file.buffer, maxDataRowsForUpload);
-
-    if (result.status === 'fileEmpty') {
-      return { propertyName: 'additionalClaimantSpreadsheetName', errorType: 'fileEmpty' };
+    if (result.status !== 'ok') {
+      return [this.buildSimpleError(SIMPLE_STATUS_ERROR_TYPE[result.status])];
     }
 
-    if (result.status === 'noDataRows') {
-      return { propertyName: 'additionalClaimantSpreadsheetName', errorType: 'noDataRows' };
-    }
-
-    if (result.status === 'dataRowsExceedsMax') {
-      return { propertyName: 'additionalClaimantSpreadsheetName', errorType: 'dataRowsExceedsMax' };
-    }
-
-    if (result.status === 'ok' && result.invalidRows.length > 0) {
-      const joined = result.invalidRows.join(', ');
-      req.session.additionalClaimantInvalidRows = joined;
-
-      return {
-        propertyName: 'additionalClaimantSpreadsheetName',
-        errorType: 'invalidRowData',
-        fieldName: joined,
-      };
-    }
-
-    req.session.additionalClaimantInvalidRows = undefined;
-    return null;
+    return this.buildRowValidationErrors(result.errorsByType);
   }
 
   /**
@@ -89,5 +138,119 @@ export class AdditionalClaimantSpreadsheetService {
     }
 
     return fromApiFormatDocument(result.data);
+  }
+
+  /**
+   * Builds the full list of row-level ValidationErrors: an optional summary
+   * error first (when 3+ distinct problems were found), followed by one
+   * error per distinct problem type.
+   */
+  private buildRowValidationErrors(errorsByType: Partial<Record<FieldErrorType, number[]>>): ValidationError[] {
+    const errorTypesWithRows = this.getErrorTypesWithRows(errorsByType);
+    const errors = errorTypesWithRows.map(errorType =>
+      this.buildErrorForType(errorType, errorsByType[errorType] ?? [])
+    );
+
+    if (errorTypesWithRows.length < MULTIPLE_ERROR_TYPES_SUMMARY_MIN_TYPES) {
+      return errors;
+    }
+
+    return [this.buildSummaryError(errorTypesWithRows, errorsByType), ...errors];
+  }
+
+  /**
+   * Returns the field error types that actually have affected rows,
+   * in fixed display order.
+   */
+  private getErrorTypesWithRows(errorsByType: Partial<Record<FieldErrorType, number[]>>): FieldErrorType[] {
+    return ERROR_TYPE_ORDER.filter(errorType => (errorsByType[errorType]?.length ?? 0) > 0);
+  }
+
+  /**
+   * Builds the single ValidationError for one error type, choosing between
+   * a "too many rows to list" summary and a full row listing depending on
+   * how many rows were affected.
+   */
+  private buildErrorForType(errorType: FieldErrorType, rows: number[]): ValidationError {
+    if (rows.length > MAX_ROWS_PER_ERROR_TYPE_BEFORE_SUMMARY_MESSAGE) {
+      return this.buildTooManyRowsError(errorType, rows);
+    }
+
+    return this.buildListedRowsError(errorType, rows);
+  }
+
+  /**
+   * Builds a condensed error for when too many rows share the same problem
+   * to list individually, e.g. "42 rows are missing mandatory fields".
+   */
+  private buildTooManyRowsError(errorType: FieldErrorType, rows: number[]): ValidationError {
+    const tooManyRowsErrorType = TOO_MANY_ROWS_ERROR_TYPE_MAP[errorType];
+
+    if (errorType === 'missingMandatory') {
+      return {
+        propertyName: SPREADSHEET_PROPERTY_NAME,
+        errorType: tooManyRowsErrorType,
+        fieldName: String(rows.length),
+      };
+    }
+
+    return {
+      propertyName: SPREADSHEET_PROPERTY_NAME,
+      errorType: tooManyRowsErrorType,
+      fieldName: INVALID_FIELD_LABEL_KEY_MAP[errorType],
+      fieldName2: String(rows.length),
+    };
+  }
+
+  /**
+   * Builds an error that lists out the specific affected row numbers,
+   * e.g. "Postcode is invalid on rows 3, 7, 12".
+   */
+  private buildListedRowsError(errorType: FieldErrorType, rows: number[]): ValidationError {
+    const rowList = rows.join(', ');
+
+    if (errorType === 'missingMandatory') {
+      return {
+        propertyName: SPREADSHEET_PROPERTY_NAME,
+        errorType,
+        fieldName: rowList,
+      };
+    }
+
+    return {
+      propertyName: SPREADSHEET_PROPERTY_NAME,
+      errorType:
+        rows.length === 1
+          ? GENERIC_INVALID_FIELD_SINGLE_ROW_ERROR_TYPE
+          : GENERIC_INVALID_FIELD_MULTIPLE_ROWS_ERROR_TYPE,
+      fieldName: INVALID_FIELD_LABEL_KEY_MAP[errorType],
+      fieldName2: rowList,
+    };
+  }
+
+  /**
+   * Builds the leading summary error shown when 3+ distinct problem types
+   * were found, e.g. "17 errors found across 12 rows".
+   */
+  private buildSummaryError(
+    errorTypesWithRows: FieldErrorType[],
+    errorsByType: Partial<Record<FieldErrorType, number[]>>
+  ): ValidationError {
+    const totalErrorCount = errorTypesWithRows.reduce(
+      (total, errorType) => total + (errorsByType[errorType]?.length ?? 0),
+      0
+    );
+    const affectedRows = new Set<number>(errorTypesWithRows.flatMap(errorType => errorsByType[errorType] ?? [])).size;
+
+    return {
+      propertyName: SPREADSHEET_PROPERTY_NAME,
+      errorType: MULTIPLE_ERROR_TYPES_SUMMARY_ERROR_TYPE,
+      fieldName: String(totalErrorCount),
+      fieldName2: String(affectedRows),
+    };
+  }
+
+  private buildSimpleError(errorType: string): ValidationError {
+    return { propertyName: SPREADSHEET_PROPERTY_NAME, errorType };
   }
 }

--- a/src/main/controllers/multiples/AdditionalClaimantFileUploadController.ts
+++ b/src/main/controllers/multiples/AdditionalClaimantFileUploadController.ts
@@ -95,8 +95,8 @@ export default class AdditionalClaimantFileUploadController {
 
     try {
       const sheet = await spreadsheetService.validateSpreadsheet(req);
-      if (sheet) {
-        req.session.errors.push(sheet);
+      if (sheet.length > 0) {
+        req.session.errors.push(...sheet);
         await saveAndRedirect();
         return;
       }
@@ -129,10 +129,7 @@ export default class AdditionalClaimantFileUploadController {
       TranslationKeys.ADDITIONAL_CLAIMANT_FILE_UPLOAD,
     ]);
 
-    const additionalClaimantInvalidRows = req.session.additionalClaimantInvalidRows;
     const uploadedFileName = req.session.additionalClaimantUploadedFileName;
-
-    req.session.additionalClaimantInvalidRows = undefined;
     req.session.additionalClaimantUploadedFileName = undefined;
 
     assignFormData(req.session.userCase, this.form.getFormFields());
@@ -141,7 +138,7 @@ export default class AdditionalClaimantFileUploadController {
     res.render(TranslationKeys.ADDITIONAL_CLAIMANT_FILE_UPLOAD, {
       ...content,
       postAddress: PageUrls.ADDITIONAL_CLAIMANT_FILE_UPLOAD,
-      additionalErrorInfo: additionalClaimantInvalidRows || maxDataRowsForUpload,
+      errorValue: maxDataRowsForUpload,
       uploadedFileName,
     });
   };

--- a/src/main/controllers/multiples/ReviewAdditionalClaimantsController.ts
+++ b/src/main/controllers/multiples/ReviewAdditionalClaimantsController.ts
@@ -66,8 +66,9 @@ export default class ReviewAdditionalClaimantsController {
 
   public post = async (req: AppRequest, res: Response): Promise<void> => {
     // 1. Run all claimant data validation
-    const claimantErrors = validateAdditionalClaimants(req);
-    const additionalClaimantCount = req.session?.userCase?.additionalClaimants?.length || 0;
+    const additionalClaimants = req.session?.userCase?.additionalClaimants ?? [];
+    const claimantErrors = validateAdditionalClaimants(additionalClaimants);
+    const additionalClaimantCount = additionalClaimants.length || 0;
     req.session.errors = req.session.errors || [];
 
     // When max claimants are reached, the radios are hidden and we implicitly continue.

--- a/src/main/definitions/appRequest.ts
+++ b/src/main/definitions/appRequest.ts
@@ -40,7 +40,6 @@ export interface AppSession extends Session {
   csrfInitialized?: boolean;
   deletedCaseIds?: string[];
   additionalClaimantNewFlow?: boolean;
-  additionalClaimantInvalidRows?: string;
   additionalClaimantUploadedFileName?: string;
   additionalClaimantsRedirectCheckAnswer?: boolean;
 }

--- a/src/main/definitions/form.ts
+++ b/src/main/definitions/form.ts
@@ -84,6 +84,7 @@ export type FormError = {
   propertyName: string;
   errorType: string;
   fieldName?: string;
+  fieldName2?: string;
 };
 
 export type InvalidField = {

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -9,6 +9,70 @@ import { AnyRecord } from '../../definitions/util-types';
 import { dateInLocale, dateTimeInLocale, datesStringToDateInLocale } from '../../helper/dateInLocale';
 
 import createFilters from './njkFilters';
+const ERROR_VALUE_SEPARATOR = '|';
+const PRIMARY_ERROR_VALUE_PLACEHOLDERS = ['{{errorValue}}'];
+const SECONDARY_ERROR_VALUE_PLACEHOLDERS = ['{{errorValue2}}'];
+
+const replacePlaceholders = (template: string, placeholders: string[], value: string): string => {
+  return placeholders.reduce((resolvedTemplate, placeholder) => {
+    return resolvedTemplate.split(placeholder).join(value);
+  }, template);
+};
+
+/**
+ * Resolves every session error attached to a given field into its
+ * translated, placeholder-interpolated display message(s).
+ */
+export const resolveFieldErrorMessages = (
+  sessionErrors: FormError[] | undefined,
+  errors: AnyRecord,
+  fieldName: string,
+  defaultErrorValue?: string | number
+): string[] => {
+  if (!sessionErrors?.length || !errors?.[fieldName]) {
+    return [];
+  }
+
+  return sessionErrors
+    .filter((error: FormError) => error.propertyName === fieldName)
+    .map((fieldError: FormError) => {
+      const fieldErrorTranslations = errors[fieldName];
+      const template = fieldErrorTranslations[fieldError.errorType];
+      if (typeof template !== 'string') {
+        return null;
+      }
+      const placeholderValue = fieldError.fieldName ?? defaultErrorValue;
+      if (placeholderValue === undefined || placeholderValue === null) {
+        return template;
+      }
+      let rawPrimaryValue = String(placeholderValue);
+      let secondaryValue = fieldError.fieldName2;
+      if (secondaryValue === undefined) {
+        const splitValues = rawPrimaryValue.split(ERROR_VALUE_SEPARATOR);
+        if (splitValues.length > 1) {
+          rawPrimaryValue = splitValues[0];
+          secondaryValue = splitValues.slice(1).join(ERROR_VALUE_SEPARATOR);
+        }
+      }
+      const primaryValue = fieldErrorTranslations.invalidFieldLabels?.[rawPrimaryValue] ?? rawPrimaryValue;
+      let resolvedMessage = replacePlaceholders(template, PRIMARY_ERROR_VALUE_PLACEHOLDERS, primaryValue);
+      resolvedMessage = replacePlaceholders(resolvedMessage, SECONDARY_ERROR_VALUE_PLACEHOLDERS, secondaryValue ?? '');
+      return resolvedMessage;
+    })
+    .filter((text): text is string => !!text);
+};
+
+export const formatInlineFieldError = (fieldMessages: string[]): { text?: string; html?: string } | null => {
+  if (!fieldMessages.length) {
+    return null;
+  }
+
+  if (fieldMessages.length > 1) {
+    return { html: fieldMessages.join('<br>') };
+  }
+
+  return { text: fieldMessages[0] };
+};
 
 export class Nunjucks {
   constructor(public developmentMode: boolean) {
@@ -36,73 +100,40 @@ export class Nunjucks {
       }
     );
 
-    nunEnv.addGlobal('getError', function (fieldName: string): { text?: string; fieldName?: string } | boolean {
-      const { sessionErrors, errors, additionalErrorInfo } = this.ctx;
-
-      if (!sessionErrors?.length) {
-        return false;
-      }
-
-      const fieldError = sessionErrors.find((error: FormError) => error.propertyName === fieldName);
-      if (!fieldError) {
-        return false;
-      }
-
-      if (!errors?.[fieldName]) {
-        return false;
-      }
-
-      let text = errors[fieldName][fieldError.errorType];
-
-      // Interpolate any placeholders using values from the render context
-      if (additionalErrorInfo) {
-        text = text.replace('{{additionalErrorInfo}}', additionalErrorInfo);
-      }
-
-      return { text };
+    nunEnv.addGlobal('getError', function (fieldName: string): { text?: string; html?: string } | boolean {
+      const { sessionErrors, errors } = this.ctx;
+      const defaultErrorValue = this.ctx.errorValue;
+      const fieldMessages = resolveFieldErrorMessages(sessionErrors, errors, fieldName, defaultErrorValue);
+      const formattedError = formatInlineFieldError(fieldMessages);
+      return formattedError ?? false;
     });
 
-    nunEnv.addGlobal('getErrors', function (items: FormFields[]): {
-      text?: string;
-      href?: string;
-    }[] {
+    nunEnv.addGlobal('getErrors', function (items: FormFields): { text?: string; href?: string }[] {
+      const { sessionErrors, errors } = this.ctx;
+      const defaultErrorValue = this.ctx.errorValue;
+
       return Object.entries(items)
         .flatMap(([fieldName, field]) => {
-          const errors = [];
+          const fieldErrors: { text: string; href: string }[] = [];
 
           if (field.values) {
             for (const value of field.values as unknown as FormField[]) {
               if (value.subFields) {
-                const subFields = Object.entries(value.subFields);
-                subFields.flatMap(([subFieldName, subField]) => {
-                  const subFieldError = this.env.globals.getError.call(this, subFieldName) as {
-                    text?: string;
-                    fieldName?: string;
-                  };
-                  if (subFieldError && subFieldError?.text) {
-                    errors.push({
-                      text: subFieldError.text,
-                      href: `#${subField.id}`,
-                    });
-                  }
+                Object.entries(value.subFields).forEach(([subFieldName, subField]) => {
+                  resolveFieldErrorMessages(sessionErrors, errors, subFieldName, defaultErrorValue).forEach(message => {
+                    fieldErrors.push({ text: message, href: `#${subField.id}` });
+                  });
                 });
               }
             }
           }
+          resolveFieldErrorMessages(sessionErrors, errors, fieldName, defaultErrorValue).forEach(message => {
+            fieldErrors.push({ text: message, href: `#${field.id}` });
+          });
 
-          const error = this.env.globals.getError.call(this, fieldName) as {
-            text?: string;
-            fieldName?: string;
-          };
-          if (error && error?.text) {
-            errors.push({
-              text: error.text,
-              href: `#${field.id}`,
-            });
-          }
-          return errors;
+          return fieldErrors;
         })
-        .filter(e => e);
+        .filter(Boolean);
     });
 
     nunEnv.addGlobal(

--- a/src/main/resources/locales/cy/translation/additional-claimant-file-upload.json
+++ b/src/main/resources/locales/cy/translation/additional-claimant-file-upload.json
@@ -1,45 +1,63 @@
 {
-  "title": "[W] Add claimants using a spreadsheet",
-  "h1": "[W] Add claimants using a spreadsheet",
+  "title": "[W]Add claimants using a spreadsheet",
+  "h1": "[W]Add claimants using a spreadsheet",
   "section1": {
-    "heading": "[W] Download and complete the spreadsheet template",
-    "p1": "[W] Download the spreadsheet template or use you own if it follows the same format.",
-    "link": "[W] Group claims template (xlsx, 12KB)",
-    "linkUrl": "/resources/xlsx/group-claims-template-cy.xlsx",
-    "p3": "[W] If you are using your own file, ensure your header row includes these exact columns, with the correct spelling:",
+    "heading": "[W]Download and complete the spreadsheet template",
+    "p1": "[W]Download the spreadsheet template or use you own if it follows the same format.",
+    "link": "[W]Group claims template (xlsx, 12KB)",
+    "linkUrl": "[W]/resources/xlsx/group-claims-template.xlsx",
+    "p3": "[W]If you are uploading your own file, you must include all of the following mandatory columns in your header row, using the exact spelling shown:",
     "columnNames": ["First name", "Last name", "Address line 1", "Town or city", "Country"]
   },
   "section2": {
-    "heading": "[W] Save in Excel format",
-    "p1": "[W] Follow these steps:",
+    "heading": "[W]Save in Excel format",
+    "p1": "[W]Follow these steps:",
     "steps": ["select 'File'", "select 'Save as' or 'Export to'", "save as the format 'Excel (.xlsx or .xls)'"]
   },
   "section3": {
-    "heading": "[W] Upload spreadsheet",
-    "p1": "[W] Select 'Choose file', browse to your saved spreadsheet and select it.",
-    "buttonLabel": "[W] Choose file"
+    "heading": "[W]Upload spreadsheet",
+    "p1": "[W]Select 'Choose file', browse to your saved spreadsheet and select it.",
+    "buttonLabel": "[W]Choose file"
   },
   "fileUpload": {
-    "chooseFiles": "[W] Choose file",
-    "dropInstruction": "[W] or drop file",
-    "noFileChosen": "[W] No file chosen"
+    "chooseFiles": "[W]Choose file",
+    "dropInstruction": "[W]or drop file",
+    "noFileChosen": "[W]No file chosen"
   },
   "errors": {
     "additionalClaimantSpreadsheetName": {
-      "required": "[W] Please upload a spreadsheet",
-      "invalidFileSize": "[W] The file size must be less than 5MB",
-      "invalidFileFormat": "[W] The selected file must be an Excel spreadsheet (.xlsx or .xls)",
-      "invalidRowData": "[W] The following rows contain invalid data: {{additionalErrorInfo}}.",
-      "backEndError": "[W] Backend error occurred while processing the file. Please try again later.",
-      "fileEmpty": "[W] The uploaded file is empty. Upload a file with data.",
-      "noDataRows": "[W] The uploaded file does not contain any data rows. Please upload a file with data.",
-      "dataRowsExceedsMax": "[W] The uploaded file has exceeded the maximum of {{additionalErrorInfo}} rows."
+      "required": "[W]Please upload a spreadsheet",
+      "invalidFileSize": "[W]The file size must be less than 5MB",
+      "invalidFileFormat": "[W]The selected file must be an Excel spreadsheet (.xlsx or .xls)",
+      "invalidRowData": "[W]The following rows contain invalid data: {{errorValue}}.",
+      "backEndError": "[W]Backend error occurred while processing the file. Please try again later.",
+      "fileEmpty": "[W]The uploaded file is empty. Upload a file with data.",
+      "noDataRows": "[W]The uploaded file does not contain any data rows. Please upload a file with data.",
+      "dataRowsExceedsMax": "[W]The uploaded file has exceeded the maximum of {{errorValue}} rows.",
+      "missingMandatory": "[W]There's mandatory data missing for rows {{errorValue}}",
+      "invalidFieldSingleRow": "[W]{{errorValue}} is invalid for row {{errorValue2}}",
+      "invalidFieldMultipleRows": "[W]{{errorValue}} is invalid for rows {{errorValue2}}",
+      "missingMandatoryTooManyRows": "[W]Mandatory data is missing on {{errorValue}} rows.",
+      "invalidFieldTooManyRows": "[W]{{errorValue}} is invalid on {{errorValue2}} rows.",
+      "invalidFieldLabels": {
+        "title": "[W]Title",
+        "firstName": "[W]First name",
+        "lastName": "[W]Last name",
+        "addressLine1": "[W]Address line 1",
+        "addressLine2": "[W]Address line 2",
+        "townOrCity": "[W]Town or city",
+        "country": "[W]Country",
+        "dateOfBirth": "[W]Date of birth",
+        "emailAddress": "[W]Email address",
+        "postcode": "[W]Postcode"
+      },
+      "multipleErrorTypesSummary": "[W]There are {{errorValue}} errors over {{errorValue2}} rows within the uploaded file."
     }
   },
-  "successTitle": "[W] Success",
-  "successHeading": "[W] Document upload successful",
-  "successBody": "[W] has been uploaded.",
-  "uploadedDocument": "[W] Uploaded document",
-  "uploadedTag": "[W] Uploaded",
-  "removeLink": "[W] Remove"
+  "successTitle": "[W]Success",
+  "successHeading": "[W]Document upload successful",
+  "successBody": "[W]has been uploaded.",
+  "uploadedDocument": "[W]Uploaded document",
+  "uploadedTag": "[W]Uploaded",
+  "removeLink": "[W]Remove"
 }

--- a/src/main/resources/locales/en/translation/additional-claimant-file-upload.json
+++ b/src/main/resources/locales/en/translation/additional-claimant-file-upload.json
@@ -6,7 +6,7 @@
     "p1": "Download the spreadsheet template or use you own if it follows the same format.",
     "link": "Group claims template (xlsx, 12KB)",
     "linkUrl": "/resources/xlsx/group-claims-template.xlsx",
-    "p3": "If you are using your own file, ensure your header row includes these exact columns, with the correct spelling:",
+    "p3": "If you are uploading your own file, you must include all of the following mandatory columns in your header row, using the exact spelling shown:",
     "columnNames": ["First name", "Last name", "Address line 1", "Town or city", "Country"]
   },
   "section2": {
@@ -29,11 +29,29 @@
       "required": "Please upload a spreadsheet",
       "invalidFileSize": "The file size must be less than 5MB",
       "invalidFileFormat": "The selected file must be an Excel spreadsheet (.xlsx or .xls)",
-      "invalidRowData": "The following rows contain invalid data: {{additionalErrorInfo}}.",
+      "invalidRowData": "The following rows contain invalid data: {{errorValue}}.",
       "backEndError": "Backend error occurred while processing the file. Please try again later.",
       "fileEmpty": "The uploaded file is empty. Upload a file with data.",
       "noDataRows": "The uploaded file does not contain any data rows. Please upload a file with data.",
-      "dataRowsExceedsMax": "The uploaded file has exceeded the maximum of {{additionalErrorInfo}} rows."
+      "dataRowsExceedsMax": "The uploaded file has exceeded the maximum of {{errorValue}} rows.",
+      "missingMandatory": "There's mandatory data missing for rows {{errorValue}}",
+      "invalidFieldSingleRow": "{{errorValue}} is invalid for row {{errorValue2}}",
+      "invalidFieldMultipleRows": "{{errorValue}} is invalid for rows {{errorValue2}}",
+      "missingMandatoryTooManyRows": "Mandatory data is missing on {{errorValue}} rows.",
+      "invalidFieldTooManyRows": "{{errorValue}} is invalid on {{errorValue2}} rows.",
+      "invalidFieldLabels": {
+        "title": "Title",
+        "firstName": "First name",
+        "lastName": "Last name",
+        "addressLine1": "Address line 1",
+        "addressLine2": "Address line 2",
+        "townOrCity": "Town or city",
+        "country": "Country",
+        "dateOfBirth": "Date of birth",
+        "emailAddress": "Email address",
+        "postcode": "Postcode"
+      },
+      "multipleErrorTypesSummary": "There are {{errorValue}} errors over {{errorValue2}} rows within the uploaded file."
     }
   },
   "successTitle": "Success",

--- a/src/main/validators/multiples/additionalClaimantUploadValidator.ts
+++ b/src/main/validators/multiples/additionalClaimantUploadValidator.ts
@@ -12,6 +12,19 @@ type FieldKey =
   | 'country'
   | 'postcode';
 
+export type FieldErrorType =
+  | 'missingMandatory'
+  | 'invalidTitle'
+  | 'invalidFirstName'
+  | 'invalidLastName'
+  | 'invalidAddressLine1'
+  | 'invalidAddressLine2'
+  | 'invalidTown'
+  | 'invalidCountry'
+  | 'invalidDob'
+  | 'invalidEmail'
+  | 'invalidPostcode';
+
 /**
  * Normalises a spreadsheet header by trimming, lowercasing, and removing spaces.
  */
@@ -155,9 +168,47 @@ const EMAIL_PATTERN = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const POSTCODE_PATTERN = /^[A-Z]{1,2}[0-9][0-9A-Z]?\s?[0-9][A-Z]{2}$/i;
 
 /**
- * Validates a single spreadsheet row against business rules.
+ * Validates a DOB string: format, calendar validity, and age range (16-100).
  */
-export const rowIsInvalid = (row: unknown[], map: Record<FieldKey, number>): boolean => {
+const isValidDob = (dob: string): boolean => {
+  const match = DOB_PATTERN.exec(dob);
+
+  if (!match) {
+    return false;
+  }
+
+  const day = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10) - 1;
+  const year = Number.parseInt(match[3], 10);
+
+  const date = new Date(year, month, day);
+
+  if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
+    return false;
+  }
+
+  const today = new Date();
+  const minAgeDate = new Date(today.getFullYear() - 16, today.getMonth(), today.getDate());
+  const maxAgeDate = new Date(today.getFullYear() - 100, today.getMonth(), today.getDate());
+
+  if (date > minAgeDate) {
+    return false;
+  }
+
+  if (date < maxAgeDate) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Validates a single spreadsheet row against business rules and returns
+ * the set of specific error types found (empty set if the row is valid).
+ */
+export const getRowErrorTypes = (row: unknown[], map: Record<FieldKey, number>): Set<FieldErrorType> => {
+  const errors = new Set<FieldErrorType>();
+
   const title = get(row, map, 'title');
   const firstName = get(row, map, 'firstName');
   const lastName = get(row, map, 'lastName');
@@ -169,100 +220,84 @@ export const rowIsInvalid = (row: unknown[], map: Record<FieldKey, number>): boo
   const country = get(row, map, 'country');
   const postcode = get(row, map, 'postcode');
 
-  if (title) {
-    if (title.length > 25) {
-      return true;
-    }
-    if (!NAME_PATTERN.test(title)) {
-      return true;
-    }
+  // Title (optional)
+  if (title && (title.length > 25 || !NAME_PATTERN.test(title))) {
+    errors.add('invalidTitle');
   }
 
-  if (!firstName || firstName.length > 100 || !NAME_PATTERN.test(firstName)) {
-    return true;
+  // First name (mandatory)
+  if (!firstName) {
+    errors.add('missingMandatory');
+  } else if (firstName.length > 100 || !NAME_PATTERN.test(firstName)) {
+    errors.add('invalidFirstName');
   }
 
-  if (!lastName || lastName.length > 100 || !NAME_PATTERN.test(lastName)) {
-    return true;
+  // Last name (mandatory)
+  if (!lastName) {
+    errors.add('missingMandatory');
+  } else if (lastName.length > 100 || !NAME_PATTERN.test(lastName)) {
+    errors.add('invalidLastName');
   }
 
-  if (!addrLine1 || addrLine1.length > 150 || !ADDRESS_PATTERN.test(addrLine1)) {
-    return true;
+  // Address line 1 (mandatory)
+  if (!addrLine1) {
+    errors.add('missingMandatory');
+  } else if (addrLine1.length > 150 || !ADDRESS_PATTERN.test(addrLine1)) {
+    errors.add('invalidAddressLine1');
   }
 
+  // Address line 2 (optional)
   if (addrLine2 && (addrLine2.length > 50 || !ADDRESS_PATTERN.test(addrLine2))) {
-    return true;
+    errors.add('invalidAddressLine2');
   }
 
-  if (!town || town.length > 50 || !TOWN_PATTERN.test(town)) {
-    return true;
+  // Town (mandatory)
+  if (!town) {
+    errors.add('missingMandatory');
+  } else if (town.length > 50 || !TOWN_PATTERN.test(town)) {
+    errors.add('invalidTown');
   }
 
-  if (!country || country.length > 50 || !COUNTRY_PATTERN.test(country)) {
-    return true;
+  // Country (mandatory)
+  if (!country) {
+    errors.add('missingMandatory');
+  } else if (country.length > 50 || !COUNTRY_PATTERN.test(country)) {
+    errors.add('invalidCountry');
   }
 
-  if (dob) {
-    const match = DOB_PATTERN.exec(dob);
-
-    if (!match) {
-      return true;
-    }
-
-    const day = Number.parseInt(match[1], 10);
-    const month = Number.parseInt(match[2], 10) - 1;
-    const year = Number.parseInt(match[3], 10);
-
-    const date = new Date(year, month, day);
-
-    if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
-      return true;
-    }
-
-    const today = new Date();
-    const minAgeDate = new Date(today.getFullYear() - 16, today.getMonth(), today.getDate());
-    const maxAgeDate = new Date(today.getFullYear() - 100, today.getMonth(), today.getDate());
-
-    if (date > minAgeDate) {
-      return true;
-    }
-
-    if (date < maxAgeDate) {
-      return true;
-    }
+  // Date of birth (optional)
+  if (dob && !isValidDob(dob)) {
+    errors.add('invalidDob');
   }
 
-  if (email) {
-    if (email.length > 100) {
-      return true;
-    }
-
-    if (!EMAIL_PATTERN.test(email)) {
-      return true;
-    }
+  // Email (optional)
+  if (email && (email.length > 100 || !EMAIL_PATTERN.test(email))) {
+    errors.add('invalidEmail');
   }
 
-  if (postcode) {
-    if (postcode.length > 14) {
-      return true;
-    }
-
-    if (!POSTCODE_PATTERN.test(postcode)) {
-      return true;
-    }
+  // Postcode (optional)
+  if (postcode && (postcode.length > 14 || !POSTCODE_PATTERN.test(postcode))) {
+    errors.add('invalidPostcode');
   }
 
-  return false;
+  return errors;
 };
 
+/**
+ * Convenience boolean wrapper, kept for any existing callers that only
+ * need a yes/no answer.
+ */
+export const rowIsInvalid = (row: unknown[], map: Record<FieldKey, number>): boolean =>
+  getRowErrorTypes(row, map).size > 0;
+
 type SpreadsheetValidationResult =
-  | { status: 'ok'; invalidRows: number[] }
+  | { status: 'ok'; errorsByType: Partial<Record<FieldErrorType, number[]>> }
   | { status: 'fileEmpty' }
   | { status: 'noDataRows' }
   | { status: 'dataRowsExceedsMax' };
 
 /**
- * Validates spreadsheet buffer and returns row numbers that fail validation.
+ * Validates spreadsheet buffer and returns row numbers grouped by error type.
  */
 export const validateSpreadsheetData = async (
   buffer: Buffer,
@@ -295,14 +330,17 @@ export const validateSpreadsheetData = async (
     return { status: 'dataRowsExceedsMax' };
   }
 
-  const invalidNums: number[] = [];
   const headerMap = buildHeaderMap(rows[0]);
+  const errorsByType: Partial<Record<FieldErrorType, number[]>> = {};
 
   dataRows.forEach((row, idx) => {
-    if (rowIsInvalid(row, headerMap)) {
-      invalidNums.push(idx + 2);
-    }
+    const rowNumber = idx + 2;
+    const rowErrors = getRowErrorTypes(row, headerMap);
+
+    rowErrors.forEach(errorType => {
+      (errorsByType[errorType] ??= []).push(rowNumber);
+    });
   });
 
-  return { status: 'ok', invalidRows: invalidNums };
+  return { status: 'ok', errorsByType };
 };

--- a/src/test/unit/components/group-claims-validator.test.ts
+++ b/src/test/unit/components/group-claims-validator.test.ts
@@ -17,7 +17,7 @@ describe('group-claims-validator', () => {
         },
       ];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toHaveLength(0);
     });
@@ -31,7 +31,7 @@ describe('group-claims-validator', () => {
         },
       ];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toEqual(expect.arrayContaining([{ propertyName: 'hiddenErrorField', errorType: 'nameRequired' }]));
     });
@@ -45,7 +45,7 @@ describe('group-claims-validator', () => {
         },
       ];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toEqual(expect.arrayContaining([{ propertyName: 'hiddenErrorField', errorType: 'nameRequired' }]));
     });
@@ -60,7 +60,7 @@ describe('group-claims-validator', () => {
         },
       ];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toEqual(expect.arrayContaining([{ propertyName: 'hiddenErrorField', errorType: 'nameRequired' }]));
     });
@@ -69,7 +69,7 @@ describe('group-claims-validator', () => {
       const req = mockRequest({});
       req.session.userCase.additionalClaimants = [{ firstName: 'Jane', lastName: 'Doe' }];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toEqual(
         expect.arrayContaining([{ propertyName: 'hiddenErrorField', errorType: 'addressRequired' }])
@@ -86,7 +86,7 @@ describe('group-claims-validator', () => {
         },
       ];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toEqual(
         expect.arrayContaining([{ propertyName: 'hiddenErrorField', errorType: 'addressRequired' }])
@@ -103,7 +103,7 @@ describe('group-claims-validator', () => {
         },
       ];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toEqual(
         expect.arrayContaining([{ propertyName: 'hiddenErrorField', errorType: 'addressRequired' }])
@@ -120,7 +120,7 @@ describe('group-claims-validator', () => {
         },
       ];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toEqual(
         expect.arrayContaining([{ propertyName: 'hiddenErrorField', errorType: 'addressRequired' }])
@@ -131,7 +131,7 @@ describe('group-claims-validator', () => {
       const req = mockRequest({});
       req.session.userCase.additionalClaimants = [{}];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toEqual(
         expect.arrayContaining([
@@ -145,7 +145,7 @@ describe('group-claims-validator', () => {
       const req = mockRequest({});
       req.session.userCase.additionalClaimants = undefined;
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toHaveLength(0);
     });
@@ -154,7 +154,7 @@ describe('group-claims-validator', () => {
       const req = mockRequest({});
       req.session.userCase.additionalClaimants = [];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toHaveLength(0);
     });
@@ -170,7 +170,7 @@ describe('group-claims-validator', () => {
         { firstName: 'Missing', lastName: 'Address' },
       ];
 
-      const errors = validateAdditionalClaimants(req);
+      const errors = validateAdditionalClaimants(req.session.userCase.additionalClaimants);
 
       expect(errors).toHaveLength(1);
       expect(errors[0].errorType).toBe('addressRequired');

--- a/src/test/unit/controller/helpers/multiples/AdditionalClaimantFileUploadService.test.ts
+++ b/src/test/unit/controller/helpers/multiples/AdditionalClaimantFileUploadService.test.ts
@@ -33,7 +33,6 @@ describe('AdditionalClaimantSpreadsheetService', () => {
       },
     });
 
-    // Safeguard to ensure session object exists for mapping claimants
     if (!req.session) {
       req.session = {} as never;
     }
@@ -84,15 +83,28 @@ describe('AdditionalClaimantSpreadsheetService', () => {
   });
 
   describe('validateSpreadsheet', () => {
+    it('should return required error when file is missing', async () => {
+      req.file = undefined;
+
+      await expect(service.validateSpreadsheet(req)).resolves.toEqual([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'required',
+        },
+      ]);
+    });
+
     it('should return fileEmpty error', async () => {
       jest.spyOn(validator, 'validateSpreadsheetData').mockResolvedValue({
         status: 'fileEmpty',
       } as never);
 
-      await expect(service.validateSpreadsheet(req)).resolves.toEqual({
-        propertyName: 'additionalClaimantSpreadsheetName',
-        errorType: 'fileEmpty',
-      });
+      await expect(service.validateSpreadsheet(req)).resolves.toEqual([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'fileEmpty',
+        },
+      ]);
     });
 
     it('should return noDataRows error', async () => {
@@ -100,10 +112,12 @@ describe('AdditionalClaimantSpreadsheetService', () => {
         status: 'noDataRows',
       } as never);
 
-      await expect(service.validateSpreadsheet(req)).resolves.toEqual({
-        propertyName: 'additionalClaimantSpreadsheetName',
-        errorType: 'noDataRows',
-      });
+      await expect(service.validateSpreadsheet(req)).resolves.toEqual([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'noDataRows',
+        },
+      ]);
     });
 
     it('should return dataRowsExceedsMax error', async () => {
@@ -111,38 +125,100 @@ describe('AdditionalClaimantSpreadsheetService', () => {
         status: 'dataRowsExceedsMax',
       } as never);
 
-      await expect(service.validateSpreadsheet(req)).resolves.toEqual({
-        propertyName: 'additionalClaimantSpreadsheetName',
-        errorType: 'dataRowsExceedsMax',
-      });
+      await expect(service.validateSpreadsheet(req)).resolves.toEqual([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'dataRowsExceedsMax',
+        },
+      ]);
     });
 
-    it('should return invalidRowData and set invalid rows', async () => {
+    it('should return grouped validation errors with per-error row lists', async () => {
       jest.spyOn(validator, 'validateSpreadsheetData').mockResolvedValue({
         status: 'ok',
-        invalidRows: [2, 5, 8],
-      });
+        errorsByType: {
+          missingMandatory: [2, 5],
+          invalidEmail: [8],
+        },
+      } as never);
 
-      await expect(service.validateSpreadsheet(req)).resolves.toEqual({
-        propertyName: 'additionalClaimantSpreadsheetName',
-        errorType: 'invalidRowData',
-        fieldName: '2, 5, 8',
-      });
-
-      expect(req.session.additionalClaimantInvalidRows).toBe('2, 5, 8');
+      await expect(service.validateSpreadsheet(req)).resolves.toEqual([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'missingMandatory',
+          fieldName: '2, 5',
+        },
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'invalidFieldSingleRow',
+          fieldName: 'emailAddress',
+          fieldName2: '8',
+        },
+      ]);
     });
 
-    it('should clear invalid rows and return null when spreadsheet is valid', async () => {
-      req.session.additionalClaimantInvalidRows = '2, 3';
-
+    it('should return per-error-type threshold message when an error type has more than 10 rows', async () => {
       jest.spyOn(validator, 'validateSpreadsheetData').mockResolvedValue({
         status: 'ok',
-        invalidRows: [],
-      });
+        errorsByType: {
+          invalidTitle: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        },
+      } as never);
 
-      await expect(service.validateSpreadsheet(req)).resolves.toBeNull();
+      await expect(service.validateSpreadsheet(req)).resolves.toEqual([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'invalidFieldTooManyRows',
+          fieldName: 'title',
+          fieldName2: '11',
+        },
+      ]);
+    });
 
-      expect(req.session.additionalClaimantInvalidRows).toBeUndefined();
+    it('should prepend summary errors when there are more than two error types', async () => {
+      jest.spyOn(validator, 'validateSpreadsheetData').mockResolvedValue({
+        status: 'ok',
+        errorsByType: {
+          missingMandatory: [2, 3],
+          invalidDob: [3, 4],
+          invalidEmail: [4],
+        },
+      } as never);
+
+      await expect(service.validateSpreadsheet(req)).resolves.toEqual([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'multipleErrorTypesSummary',
+          fieldName: '5',
+          fieldName2: '3',
+        },
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'missingMandatory',
+          fieldName: '2, 3',
+        },
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'invalidFieldMultipleRows',
+          fieldName: 'dateOfBirth',
+          fieldName2: '3, 4',
+        },
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'invalidFieldSingleRow',
+          fieldName: 'emailAddress',
+          fieldName2: '4',
+        },
+      ]);
+    });
+
+    it('should return empty array when spreadsheet is valid', async () => {
+      jest.spyOn(validator, 'validateSpreadsheetData').mockResolvedValue({
+        status: 'ok',
+        errorsByType: {},
+      } as never);
+
+      await expect(service.validateSpreadsheet(req)).resolves.toEqual([]);
     });
 
     it('should use configured max rows when present', async () => {
@@ -150,8 +226,8 @@ describe('AdditionalClaimantSpreadsheetService', () => {
 
       const validateSpy = jest.spyOn(validator, 'validateSpreadsheetData').mockResolvedValue({
         status: 'ok',
-        invalidRows: [],
-      });
+        errorsByType: {},
+      } as never);
 
       await service.validateSpreadsheet(req);
 
@@ -163,8 +239,8 @@ describe('AdditionalClaimantSpreadsheetService', () => {
 
       const validateSpy = jest.spyOn(validator, 'validateSpreadsheetData').mockResolvedValue({
         status: 'ok',
-        invalidRows: [],
-      });
+        errorsByType: {},
+      } as never);
 
       await service.validateSpreadsheet(req);
 

--- a/src/test/unit/controller/multiples/AdditionalClaimantFileUploadController.test.ts
+++ b/src/test/unit/controller/multiples/AdditionalClaimantFileUploadController.test.ts
@@ -38,8 +38,6 @@ describe('AdditionalClaimantFileUploadController', () => {
     controller = new AdditionalClaimantFileUploadController();
   });
 
-  // ─── GET ──────────────────────────────────────────────────────────────────
-
   describe('get', () => {
     it('should render the file upload page', async () => {
       const req = mockRequestWithTranslation({ t }, {});
@@ -62,7 +60,7 @@ describe('AdditionalClaimantFileUploadController', () => {
 
       expect(res.render).toHaveBeenCalledWith(
         TranslationKeys.ADDITIONAL_CLAIMANT_FILE_UPLOAD,
-        expect.objectContaining({ additionalErrorInfo: 100 })
+        expect.objectContaining({ errorValue: 100 })
       );
     });
 
@@ -75,24 +73,20 @@ describe('AdditionalClaimantFileUploadController', () => {
 
       expect(res.render).toHaveBeenCalledWith(
         TranslationKeys.ADDITIONAL_CLAIMANT_FILE_UPLOAD,
-        expect.objectContaining({ additionalErrorInfo: 50 })
+        expect.objectContaining({ errorValue: 50 })
       );
     });
 
-    it('should clear additionalClaimantInvalidRows and uploadedFileName from session', async () => {
+    it('should clear uploadedFileName from session', async () => {
       const req = mockRequestWithTranslation({ t }, {});
-      req.session.additionalClaimantInvalidRows = '2, 3';
       req.session.additionalClaimantUploadedFileName = 'claimants.xlsx';
       const res = mockResponse();
 
       await controller.get(req, res);
 
-      expect(req.session.additionalClaimantInvalidRows).toBeUndefined();
       expect(req.session.additionalClaimantUploadedFileName).toBeUndefined();
     });
   });
-
-  // ─── POST ─────────────────────────────────────────────────────────────────
 
   describe('post', () => {
     it('should detect bot submission and return 200', async () => {
@@ -139,8 +133,6 @@ describe('AdditionalClaimantFileUploadController', () => {
       expect(res.redirect).toHaveBeenCalledWith(PageUrls.CLAIM_SAVED);
     });
   });
-
-  // ─── POST VALIDATE ────────────────────────────────────────────────────────
 
   describe('postValidate', () => {
     it('should detect bot submission and return 200', async () => {
@@ -198,10 +190,9 @@ describe('AdditionalClaimantFileUploadController', () => {
     it('should push fileEmpty error when spreadsheet is empty', async () => {
       jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validatePreconditions').mockReturnValueOnce(null);
       jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateFileFormat').mockReturnValueOnce(null);
-      jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateSpreadsheet').mockResolvedValueOnce({
-        propertyName: 'additionalClaimantSpreadsheetName',
-        errorType: 'fileEmpty',
-      });
+      jest
+        .spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateSpreadsheet')
+        .mockResolvedValueOnce([{ propertyName: 'additionalClaimantSpreadsheetName', errorType: 'fileEmpty' }]);
 
       const req = mockRequest({ body: {}, file: mockFile });
       const res = mockResponse();
@@ -216,10 +207,11 @@ describe('AdditionalClaimantFileUploadController', () => {
     it('should push dataRowsExceedsMax error when too many rows', async () => {
       jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validatePreconditions').mockReturnValueOnce(null);
       jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateFileFormat').mockReturnValueOnce(null);
-      jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateSpreadsheet').mockResolvedValueOnce({
-        propertyName: 'additionalClaimantSpreadsheetName',
-        errorType: 'dataRowsExceedsMax',
-      });
+      jest
+        .spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateSpreadsheet')
+        .mockResolvedValueOnce([
+          { propertyName: 'additionalClaimantSpreadsheetName', errorType: 'dataRowsExceedsMax' },
+        ]);
 
       const req = mockRequest({ body: {}, file: mockFile });
       const res = mockResponse();
@@ -231,10 +223,50 @@ describe('AdditionalClaimantFileUploadController', () => {
       ]);
     });
 
-    it('should push uploadFailed error when document upload fails', async () => {
+    it('should keep multiple spreadsheet validation errors on additionalClaimantSpreadsheetName', async () => {
       jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validatePreconditions').mockReturnValueOnce(null);
       jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateFileFormat').mockReturnValueOnce(null);
-      jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateSpreadsheet').mockResolvedValueOnce(null);
+      jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateSpreadsheet').mockResolvedValueOnce([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'missingMandatory',
+          fieldName: '2, 4',
+        },
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'invalidFieldSingleRow',
+          fieldName: 'emailAddress',
+          fieldName2: '7',
+        },
+      ]);
+
+      const req = mockRequest({ body: {}, file: mockFile });
+      const res = mockResponse();
+
+      await controller.postValidate(req, res);
+
+      expect(req.session.errors).toEqual([
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'missingMandatory',
+          fieldName: '2, 4',
+        },
+        {
+          propertyName: 'additionalClaimantSpreadsheetName',
+          errorType: 'invalidFieldSingleRow',
+          fieldName: 'emailAddress',
+          fieldName2: '7',
+        },
+      ]);
+    });
+
+    it('should push backEndError when document upload fails', async () => {
+      jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validatePreconditions').mockReturnValueOnce(null);
+      jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateFileFormat').mockReturnValueOnce(null);
+      jest.spyOn(AdditionalClaimantSpreadsheetService.prototype, 'validateSpreadsheet').mockResolvedValueOnce([]);
+      jest
+        .spyOn(AdditionalClaimantSpreadsheetService.prototype, 'uploadDocument')
+        .mockRejectedValueOnce(new Error('Upload failed'));
 
       const req = mockRequest({ body: {}, file: mockFile });
       const res = mockResponse();
@@ -244,6 +276,7 @@ describe('AdditionalClaimantFileUploadController', () => {
       expect(req.session.errors).toEqual([
         { propertyName: 'additionalClaimantSpreadsheetName', errorType: 'backEndError' },
       ]);
+      expect(res.json).toHaveBeenCalledWith({ redirect: PageUrls.ADDITIONAL_CLAIMANT_FILE_UPLOAD });
     });
 
     it('should push backEndError and redirect when an unexpected error is thrown', async () => {
@@ -264,8 +297,6 @@ describe('AdditionalClaimantFileUploadController', () => {
       expect(res.json).toHaveBeenCalledWith({ redirect: PageUrls.ADDITIONAL_CLAIMANT_FILE_UPLOAD });
     });
   });
-
-  // ─── REMOVE ───────────────────────────────────────────────────────────────
 
   describe('remove', () => {
     it('should clear spreadsheet and uploadedFileName from session and redirect', async () => {

--- a/src/test/unit/validator/additionalClaimantUploadValidator.test.ts
+++ b/src/test/unit/validator/additionalClaimantUploadValidator.test.ts
@@ -665,19 +665,24 @@ describe('validateSpreadsheetData()', () => {
 
   it('returns ok with no invalid rows for a valid spreadsheet', async () => {
     const buffer = await buildBuffer([HEADER_ROW, VALID_ROW]);
-    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({ status: 'ok', invalidRows: [] });
+    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({ status: 'ok', errorsByType: {} });
   });
 
   it('returns ok with no invalid rows for mandatory-only row', async () => {
     const buffer = await buildBuffer([HEADER_ROW, MANDATORY_ONLY_ROW]);
-    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({ status: 'ok', invalidRows: [] });
+    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({ status: 'ok', errorsByType: {} });
   });
 
   it('returns ok with invalid row numbers for failing rows', async () => {
     const invalidRow = [...VALID_ROW];
     invalidRow[1] = '';
     const buffer = await buildBuffer([HEADER_ROW, VALID_ROW, invalidRow]);
-    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({ status: 'ok', invalidRows: [3] });
+    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({
+      status: 'ok',
+      errorsByType: {
+        missingMandatory: [3],
+      },
+    });
   });
 
   it('returns multiple invalid row numbers when multiple rows fail', async () => {
@@ -686,13 +691,23 @@ describe('validateSpreadsheetData()', () => {
     const invalidRow2 = [...VALID_ROW];
     invalidRow2[2] = '';
     const buffer = await buildBuffer([HEADER_ROW, VALID_ROW, invalidRow1, invalidRow2]);
-    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({ status: 'ok', invalidRows: [3, 4] });
+    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({
+      status: 'ok',
+      errorsByType: {
+        missingMandatory: [3, 4],
+      },
+    });
   });
 
   it('returns ok with XSS row flagged as invalid', async () => {
     const xssRow = [...VALID_ROW];
     xssRow[1] = '<script>alert(1)</script>';
     const buffer = await buildBuffer([HEADER_ROW, xssRow]);
-    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({ status: 'ok', invalidRows: [2] });
+    expect(await validateSpreadsheetData(buffer, DEFAULT_MAX_ROWS)).toEqual({
+      status: 'ok',
+      errorsByType: {
+        invalidFirstName: [2],
+      },
+    });
   });
 });


### PR DESCRIPTION
## JIRA link
[RET-6379](https://tools.hmcts.net/jira/browse/RET-6379)

## Change description
Improves validation of the additional-claimant spreadsheet upload (group claims) so that error messages are **precise about which field and which rows are invalid**, rather than reporting a single generic "these rows are invalid" message. Errors are grouped by problem type, summarised when there are many, and rendered inline against the upload field.

## What changed

### Per-field, per-row validation
- Replaced the boolean `rowIsInvalid` with `getRowErrorTypes`, which returns the specific set of problems found in a row (e.g. `missingMandatory`, `invalidEmail`, `invalidPostcode`) instead of just "invalid".
- `rowIsInvalid` is retained as a thin boolean wrapper for existing callers.
- `validateSpreadsheetData` now returns `errorsByType` (a map of error type → affected row numbers) instead of a flat `invalidRows` array.
- Extracted date-of-birth validation (format, calendar validity, 16–100 age range) into a dedicated `isValidDob` helper.

### Grouped and summarised error messages
`AdditionalClaimantSpreadsheetService.validateSpreadsheet` now returns an array of errors (rather than a single error/`null`) and builds user-facing messages with these rules:
- One error per distinct problem type, each listing its own affected rows (e.g. *"Postcode is invalid for rows 3, 7, 12"*).
- If a single error type affects **more than 10 rows**, a condensed message is shown instead of listing every row (e.g. *"Mandatory data is missing on 42 rows"*).
- If **3 or more** distinct error types are found, a summary error is prepended (e.g. *"There are 17 errors over 12 rows within the uploaded file"*).
- A missing file now returns a `required` error directly from the service.

### Inline error rendering
- Reworked the Nunjucks `getError` / `getErrors` globals and added `resolveFieldErrorMessages` and `formatInlineFieldError` helpers.
- A field can now display **multiple** error messages (joined with `<br>`).
- Added support for two interpolation placeholders (`{{errorValue}}`, `{{errorValue2}}`) and field-label lookups via `invalidFieldLabels`.

### Refactors / cleanup
- `validateAdditionalClaimants` now accepts an `AdditionalClaimant[]` directly instead of the whole `AppRequest`, decoupling it from the request/session (callers in `ReviewAdditionalClaimantsController` and `group-claims-validator` updated).
- Removed the now-unused `additionalClaimantInvalidRows` session field and renamed the render variable `additionalErrorInfo` → `errorValue`.
- Added `fieldName2` to the `FormError` / `ValidationError` types to carry the second placeholder value.

### Translations
- Added new error keys to both `en` and `cy` locale files: `missingMandatory`, `invalidFieldSingleRow`, `invalidFieldMultipleRows`, `missingMandatoryTooManyRows`, `invalidFieldTooManyRows`, `invalidFieldLabels`, and `multipleErrorTypesSummary`.
- Renamed the `{{additionalErrorInfo}}` placeholder to `{{errorValue}}`.
- Updated the "own file" guidance copy to clarify the mandatory columns requirement.

## Testing
- Updated and extended unit tests across the validator, service, controller, and group-claims validator.
- New service tests cover grouped errors, the >10-rows-per-type threshold message, the multi-error-type summary, missing-file handling, and the empty/valid case.

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
