### PR TITLE
fix: upgrade immutable to 5.1.9 to fix CVE-2026-59879 and CVE-2026-59880

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,8 @@
     "ip-address": "^10.1.1",
     "undici": "^7.25.0",
     "body-parser": "^1.20.6",
-    "js-yaml@npm:^4.1.1": "npm:4.3.0"
+    "js-yaml@npm:^4.1.1": "npm:4.3.0",
+    "immutable": "^5.1.8"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "brace-expansion": "^5.0.6",
     "form-data": "^4.0.6",
     "qs": "^6.15.2",
-    "tar": "^7.5.10",
+    "tar": "^7.5.21",
     "serialize-javascript": "^7.0.4",
     "underscore": "^1.13.8",
     "yauzl": "3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11403,10 +11403,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^5.1.5":
-  version: 5.1.6
-  resolution: "immutable@npm:5.1.6"
-  checksum: 10/4ba416dac4cc9d1cab4155bd6aefa54d5ca25e56bfee8a1d4edc3f23115b599486edafe76e91f83d22961bd065754fd705b04f052809ec967ccd71817c8dac2a
+"immutable@npm:^5.1.8":
+  version: 5.1.9
+  resolution: "immutable@npm:5.1.9"
+  checksum: 10/dc61ea6f79897320a048f193dec703dff25ad7bb633c3a0294677d2f258764c88da06e7c2b53d1aa51b6657c98d9f1c7341f49735b9b802fe6e834122cf78dcd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17954,16 +17954,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.10":
-  version: 7.5.20
-  resolution: "tar@npm:7.5.20"
+"tar@npm:^7.5.21":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/90a0fe423ac921197ad5eefc5e5f7ad7f42b06e80444c8c347c1e4112384cbe9cb53ade3ef71748eed3684888756869c2aeef6b6303c766101f3217e254d4be9
+  checksum: 10/129606384b3c895f422aaca48bf316357be6dc7aa35c1066c3f06c28acfff0be5b356e1b0a0be7c53a7a8945534ac06cec6d8e296d170d8a09c8bff67b29300e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes two HIGH severity CVEs in `immutable` and one MODERATE severity CVE in `tar`, both pulled in transitively.

### CVEs fixed

| Package | Advisory | CVE | Severity | Description |
|---|---|---|---|---|
| `immutable` | [GHSA-v56q-mh7h-f735](https://github.com/advisories/GHSA-v56q-mh7h-f735) | CVE-2026-59879 | High (7.5) | `List` 32-bit trie overflow → unrecoverable DoS |
| `immutable` | [GHSA-xvcm-6775-5m9r](https://github.com/advisories/GHSA-xvcm-6775-5m9r) | CVE-2026-59880 | High | Hash-collision algorithmic complexity DoS in `Map`/`Set` |
| `tar` | [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m) | - | Moderate (5.3) | Uncontrolled recursion in `mapHas`/`filesFilter` → stack-overflow DoS via crafted tar |

### Root causes

- `immutable 5.1.6` — transitive via `sass@1.100.0`. Both CVEs affect `>= 5.0.0-beta.1, < 5.1.8`.
- `tar 7.5.20` — transitive via `node-gyp@13.0.1`. CVE affects `<= 7.5.20`.

### Fix

Two `resolutions` entries updated in `package.json`:
- `immutable`: `^5.1.8` → resolved to `5.1.9`
- `tar`: `^7.5.10` → `^7.5.21`, resolved to `7.5.22`

### Testing

Run `yarn install && yarn npm audit --recursive --all` to confirm the advisories are no longer reported.