### PR TITLE
Ret 6665 API changes

### DIFF
--- a/src/main/controllers/ClaimantApplicationsController.ts
+++ b/src/main/controllers/ClaimantApplicationsController.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
+import { CaseWithId } from '../definitions/case';
 import { PageUrls, Roles, TranslationKeys } from '../definitions/constants';
 import { FormContent } from '../definitions/form';
 import { AnyRecord } from '../definitions/util-types';
@@ -11,6 +12,11 @@ import { getPageContent } from './helpers/FormHelpers';
 import { getLanguageParam } from './helpers/RouterHelpers';
 
 const logger = getLogger('ClaimantApplicationsController');
+
+// The matched role returned by /user-cases may or may not carry brackets (e.g. "[CREATOR]" vs
+// "CREATOR"); normalise before comparing against the bracket-free Roles constants.
+const matchesCaseUserRole = (userCase: CaseWithId, role: string): boolean =>
+  (userCase.caseUserRole ?? '').replace(/[[\]]/g, '').toUpperCase() === role;
 
 export default class ClaimantApplicationsController {
   public get = async (req: AppRequest, res: Response): Promise<void> => {
@@ -33,16 +39,20 @@ export default class ClaimantApplicationsController {
     //reset return url to prevent redirect loop after deleting a draft claim
     req.session.returnUrl = undefined;
 
-    // Fetch each tab's cases by the user's assigned case role: their own claims ([CREATOR])
-    // and the claims they are representing someone else on ([CLAIMANTNONLEGALREPRESENTATIVE]).
-    const myClaimsCases = await getUserCasesByLastModified(req, Roles.CREATOR_ROLE_WITHOUT_BRACKETS);
-    const representingCases = await getUserCasesByLastModified(req, Roles.CLAIMANT_NON_LEGAL_REP_WITHOUT_BRACKETS);
-    const userCases = [...myClaimsCases, ...representingCases];
+    // A single /user-cases call returns the user's own claims ([CREATOR]) and the claims they are
+    // representing someone else on ([CLAIMANTNONLEGALREPRESENTATIVE]) — the backend auto-expands the
+    // default/CREATOR request to include both. Each case carries its matched role in caseUserRole,
+    // which we use to split them into the two tabs.
+    const userCases = await getUserCasesByLastModified(req);
     if (userCases.length === 0) {
       req.session.hasUserCases = false;
       return res.redirect(PageUrls.HOME);
     } else {
       const languageParam = getLanguageParam(req.url);
+      const myClaimsCases = userCases.filter(c => matchesCaseUserRole(c, Roles.CREATOR_ROLE_WITHOUT_BRACKETS));
+      const representingCases = userCases.filter(c =>
+        matchesCaseUserRole(c, Roles.CLAIMANT_NON_LEGAL_REP_WITHOUT_BRACKETS)
+      );
       const myClaimsApplications = getUserApplications(myClaimsCases, translations, languageParam);
       const representingApplications = getUserApplications(representingCases, translations, languageParam);
       req.session.userCases = userCases;

--- a/src/main/definitions/api/caseApiResponse.ts
+++ b/src/main/definitions/api/caseApiResponse.ts
@@ -23,6 +23,8 @@ export interface CreateCaseResponse {
 
 export interface CaseApiDataResponse {
   id: string;
+  // Role the user holds on this case, injected by /user-cases (may be top-level or in case_data).
+  caseUserRole?: string;
   created_date: string;
   last_modified: string;
   jurisdiction?: string;
@@ -38,6 +40,7 @@ export interface CaseApiDataResponse {
 }
 
 export interface CaseData {
+  caseUserRole?: string;
   ethosCaseReference?: string;
   feeGroupReference?: string;
   caseType?: CaseType;

--- a/src/main/definitions/case.ts
+++ b/src/main/definitions/case.ts
@@ -272,6 +272,7 @@ export const enum NoAcasNumberReason {
 export interface CaseWithId extends Case {
   id: string;
   state: CaseState;
+  caseUserRole?: string;
 }
 
 export const enum YesOrNo {

--- a/src/main/helper/ApiFormatter.ts
+++ b/src/main/helper/ApiFormatter.ts
@@ -98,6 +98,7 @@ export function fromApiFormat(fromApiCaseData: CaseApiDataResponse, req?: AppReq
     tribunalCorrespondenceTelephone: fromApiCaseData.case_data?.tribunalCorrespondenceTelephone,
     state: fromApiCaseData.state,
     caseTypeId: fromApiCaseData.case_type_id,
+    caseUserRole: fromApiCaseData.caseUserRole ?? fromApiCaseData.case_data?.caseUserRole,
     claimantRepresentedQuestion: fromApiCaseData.case_data?.claimantRepresentedQuestion,
     caseType: fromApiCaseData.case_data?.caseType,
     firstName: fromApiCaseData.case_data?.claimantIndType?.claimant_first_names,

--- a/src/main/resources/locales/cy/translation/claimant-applications.json
+++ b/src/main/resources/locales/cy/translation/claimant-applications.json
@@ -17,6 +17,7 @@
   "p3": "At ddibenion preifatrwydd, bydd hawliad drafft yn cael ei ddileu 12 mis ar ôl y dyddiad y mae wedi'i greu.",
   "caseNumber": "Rhif yr achos",
   "dateSubmitted": "[W]Date submitted",
+  "claimantNameCol": "Hawlydd",
   "myClaimsTab": "[W]My ET1 claims",
   "representingTab": "[W]ET1 claims for others"
 }

--- a/src/main/resources/locales/en/translation/claimant-applications.json
+++ b/src/main/resources/locales/en/translation/claimant-applications.json
@@ -17,6 +17,7 @@
   "p3": "For privacy purposes, a draft claim will be deleted 12 months after the date it's created.",
   "caseNumber": "Case number",
   "dateSubmitted": "Date submitted",
+  "claimantNameCol": "Claimant",
   "myClaimsTab": "My ET1 claims",
   "representingTab": "ET1 claims for others"
 }

--- a/src/main/views/claimant-applications-section.njk
+++ b/src/main/views/claimant-applications-section.njk
@@ -1,17 +1,21 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {#
-  Renders the "Draft" and "Submitted" application tables for a given list of applications.
-  Imported "with context" so it can access the page translations (col1..col7, h1, h2, p3, etc.)
-  and globals (dateStringToLocale).
+  Renders the "Draft" and "Submitted" claim tables for a given list of applications.
+  Imported "with context" so it can access the page translations (col1..col7, h1, h2, p3,
+  claimantNameCol, etc.) and globals (dateStringToLocale).
+
+  When showClaimantName is true (the "ET1 claims for others" table), a leading
+  "Claimant name" column is added showing the represented claimant's name.
 #}
-{% macro applicationsSection(apps) %}
+{% macro applicationsSection(apps, showClaimantName) %}
   {% set draftApplications = [] %}
   {% set submittedApplications = [] %}
 
   {% for app in apps %}
+    {% set claimantName = ((app.userCase.firstName | default('')) + ' ' + (app.userCase.lastName | default(''))) | trim %}
     {% if app.respondents === 'undefined' and app.userCase.state === 'AWAITING_SUBMISSION_TO_HMCTS' %}
-      {% set draftApplications = (draftApplications.push([
+      {% set draftRow = [
         { text: app.userCase.createdDate },
         { text: app.userCase.id },
         { text: app.userCase.typeOfClaimString },
@@ -23,9 +27,11 @@
             '<a class="govuk-link govuk-!-margin-right-3" href="' + app.url + '" data-navigation-link aria-label="' + continue + ' ' + col2 + ': ' + app.userCase.id + '">' + continue + '</a>' +
             '<a class="govuk-link" href="' + app.deleteDraftUrl + '" data-navigation-link aria-label="' + delete + ' ' + col2 + ': ' + app.userCase.id + '">' + delete + '</a>'
         }
-      ]), draftApplications) %}
+      ] %}
+      {% if showClaimantName %}{% set draftRow = (draftRow.slice(0, 3)).concat([{ text: claimantName }]).concat(draftRow.slice(4)) %}{% endif %}
+      {% set draftApplications = (draftApplications.push(draftRow), draftApplications) %}
     {% elif app.userCase.state === 'AWAITING_SUBMISSION_TO_HMCTS' %}
-      {% set draftApplications = (draftApplications.push([
+      {% set draftRow = [
         { text: app.userCase.createdDate },
         { text: app.userCase.id },
         { text: app.userCase.typeOfClaimString },
@@ -37,15 +43,19 @@
             '<a class="govuk-link" href="' + app.url + '" data-navigation-link aria-label="' + continue + ' ' + col2 + ': ' + app.userCase.id + '">' + continue + '</a>' + '&nbsp' + '&nbsp' +
             ' <a class="govuk-link" href="' + app.deleteDraftUrl + '" data-navigation-link aria-label="' + delete + ' ' + col2 + ': ' + app.userCase.id + '" style="margin-left: 1em;">' + delete + '</a>'
         }
-      ]), draftApplications) %}
+      ] %}
+      {% if showClaimantName %}{% set draftRow = (draftRow.slice(0, 3)).concat([{ text: claimantName }]).concat(draftRow.slice(4)) %}{% endif %}
+      {% set draftApplications = (draftApplications.push(draftRow), draftApplications) %}
     {% else %}
-      {% set submittedApplications = (submittedApplications.push([
+      {% set submittedRow = [
         { text: dateStringToLocale(app.claimSubmittedDate) },
         { html: '<a class="govuk-link" href="' + app.url + '" data-navigation-link aria-label="' + view + ' ' + col2 + ': ' + app.userCase.id + '">' + app.userCase.ethosCaseReference + '</a>' },
         { text: app.userCase.typeOfClaimString },
         { text: app.respondents | safe },
         { text: app.userCase.lastModified }
-      ]), submittedApplications) %}
+      ] %}
+      {% if showClaimantName %}{% set submittedRow = (submittedRow.slice(0, 3)).concat([{ text: claimantName }]).concat(submittedRow.slice(4)) %}{% endif %}
+      {% set submittedApplications = (submittedApplications.push(submittedRow), submittedApplications) %}
     {% endif %}
   {% endfor %}
 
@@ -53,20 +63,23 @@
     <h2 class="govuk-heading-l">{{ h1 }}</h2>
     <p class="govuk-body">{{ p3 }}</p>
 
+    {% set draftHead = [
+      { text: col1 },
+      { text: col2 },
+      { text: col3 },
+      { text: col4 },
+      { text: col5 },
+      { text: col6 },
+      { text: col7 }
+    ] %}
+    {% if showClaimantName %}{% set draftHead = (draftHead.slice(0, 3)).concat([{ text: claimantNameCol }]).concat(draftHead.slice(4)) %}{% endif %}
+
     <div class="scrollableTable">
       {{ govukTable({
         caption: h1,
         captionClasses: "govuk-visually-hidden",
         firstCellIsHeader: false,
-        head: [
-          { text: col1 },
-          { text: col2 },
-          { text: col3 },
-          { text: col4 },
-          { text: col5 },
-          { text: col6 },
-          { text: col7 }
-        ],
+        head: draftHead,
         rows: draftApplications
       }) }}
     </div>
@@ -75,18 +88,21 @@
   {% if submittedApplications.length != 0 %}
     <h2 class="govuk-heading-l">{{ h2 }}</h2>
 
+    {% set submittedHead = [
+      { text: dateSubmitted },
+      { text: caseNumber },
+      { text: col3 },
+      { text: col4 },
+      { text: col6 }
+    ] %}
+    {% if showClaimantName %}{% set submittedHead = (submittedHead.slice(0, 3)).concat([{ text: claimantNameCol }]).concat(submittedHead.slice(4)) %}{% endif %}
+
     <div class="scrollableTable">
       {{ govukTable({
         caption: h2,
         captionClasses: "govuk-visually-hidden",
         firstCellIsHeader: false,
-        head: [
-          { text: dateSubmitted },
-          { text: caseNumber },
-          { text: col3 },
-          { text: col4 },
-          { text: col6 }
-        ],
+        head: submittedHead,
         rows: submittedApplications
       }) }}
     </div>

--- a/src/main/views/claimant-applications.njk
+++ b/src/main/views/claimant-applications.njk
@@ -22,7 +22,7 @@
           {
             label: representingTab,
             id: "representing",
-            panel: { html: applicationsSection(representingApplications) }
+            panel: { html: applicationsSection(representingApplications, true) }
           }
         ]
       }) }}
@@ -31,7 +31,7 @@
         {{ applicationsSection(myClaimsApplications) }}
       {% else %}
         <h2 class="govuk-heading-l">{{ representingTab }}</h2>
-        {{ applicationsSection(representingApplications) }}
+        {{ applicationsSection(representingApplications, true) }}
       {% endif %}
     {% endif %}
     </div>

--- a/src/test/unit/controller/ClaimantApplicationsController.test.ts
+++ b/src/test/unit/controller/ClaimantApplicationsController.test.ts
@@ -19,6 +19,7 @@ describe('Claimant Applications Controller', () => {
       state: CaseState.AWAITING_SUBMISSION_TO_HMCTS,
       createdDate: 'August 19, 2022',
       lastModified: 'August 19, 2022',
+      caseUserRole: Roles.CREATOR_ROLE_WITHOUT_BRACKETS,
     },
   ];
 
@@ -35,10 +36,8 @@ describe('Claimant Applications Controller', () => {
   });
 
   it('should render claimant applications page', async () => {
-    // Own claims (CREATOR) return the user's cases; representing (CLAIMANTNONLEGALREPRESENTATIVE) returns none.
-    getUserCasesMock.mockImplementation(async (_req, role) =>
-      role === Roles.CREATOR_ROLE_WITHOUT_BRACKETS ? userCases : []
-    );
+    // A single call returns all the user's cases; here just the CREATOR case, so representing is empty.
+    getUserCasesMock.mockResolvedValue(userCases);
     getUserAppMock.mockImplementation(cases => (cases.length ? mockApplications : []));
     const claimantApplicationsController = new ClaimantApplicationsController();
     const request = mockRequest({});
@@ -61,14 +60,12 @@ describe('Claimant Applications Controller', () => {
   });
 
   it('should split applications into "My claims" and "Representing" and show tabs when both exist', async () => {
-    const creatorCase = { id: 'personal-1' } as CaseWithId;
-    const repCase = { id: 'rep-1' } as CaseWithId;
+    const creatorCase = { id: 'personal-1', caseUserRole: Roles.CREATOR_ROLE_WITHOUT_BRACKETS } as CaseWithId;
+    const repCase = { id: 'rep-1', caseUserRole: Roles.CLAIMANT_NON_LEGAL_REP_WITHOUT_BRACKETS } as CaseWithId;
     const personalApp = { userCase: { id: 'personal-1' } } as ApplicationTableRecord;
     const representingApp = { userCase: { id: 'rep-1' } } as ApplicationTableRecord;
-    // Each role returns its own case; getUserApplications maps each case list to its record.
-    getUserCasesMock.mockImplementation(async (_req, role) =>
-      role === Roles.CLAIMANT_NON_LEGAL_REP_WITHOUT_BRACKETS ? [repCase] : [creatorCase]
-    );
+    // One call returns both cases; the controller splits them by caseUserRole.
+    getUserCasesMock.mockResolvedValue([creatorCase, repCase]);
     getUserAppMock.mockImplementation(cases => (cases.some(c => c.id === 'rep-1') ? [representingApp] : [personalApp]));
 
     const request = mockRequest({});
@@ -86,12 +83,10 @@ describe('Claimant Applications Controller', () => {
   });
 
   it('should not show tabs when the user has only one type of claim', async () => {
-    const repCase = { id: 'rep-1' } as CaseWithId;
+    const repCase = { id: 'rep-1', caseUserRole: Roles.CLAIMANT_NON_LEGAL_REP_WITHOUT_BRACKETS } as CaseWithId;
     const representingApp = { userCase: { id: 'rep-1' } } as ApplicationTableRecord;
-    // Only the representing ([CLAIMANTNONLEGALREPRESENTATIVE]) role returns a case.
-    getUserCasesMock.mockImplementation(async (_req, role) =>
-      role === Roles.CLAIMANT_NON_LEGAL_REP_WITHOUT_BRACKETS ? [repCase] : []
-    );
+    // Only a representing case is returned, so the "My claims" list is empty and no tabs are shown.
+    getUserCasesMock.mockResolvedValue([repCase]);
     getUserAppMock.mockImplementation(cases => (cases.some(c => c.id === 'rep-1') ? [representingApp] : []));
 
     const request = mockRequest({});

--- a/src/test/unit/helper/ApiFormatter.test.ts
+++ b/src/test/unit/helper/ApiFormatter.test.ts
@@ -237,6 +237,18 @@ describe('Format Case Data to Frontend Model', () => {
     expect(result).toStrictEqual(complete);
   });
 
+  it('should read caseUserRole from the top-level of the response', () => {
+    const mock: CaseApiDataResponse = {
+      id: '1234',
+      caseUserRole: 'CLAIMANTNONLEGALREPRESENTATIVE',
+      state: CaseState.AWAITING_SUBMISSION_TO_HMCTS,
+      created_date: '2022-08-19T09:19:25.817549',
+      last_modified: '2022-08-19T09:19:25.817549',
+      case_data: {},
+    };
+    expect(fromApiFormat(mock).caseUserRole).toEqual('CLAIMANTNONLEGALREPRESENTATIVE');
+  });
+
   it('should return undefined for empty field`', () => {
     const mockedApiDataEmpty: CaseApiDataResponse = {
       id: '1234',
@@ -255,6 +267,7 @@ describe('Format Case Data to Frontend Model', () => {
       createdDate: '19 August 2022',
       lastModified: '19 August 2022',
       state: CaseState.AWAITING_SUBMISSION_TO_HMCTS,
+      caseUserRole: undefined,
       caseType: undefined,
       typeOfClaim: undefined,
       caseTypeId: undefined,
@@ -421,6 +434,7 @@ describe('Format Case Data to Frontend Model', () => {
       createdDate: '19 August 2022',
       lastModified: '19 August 2022',
       state: CaseState.AWAITING_SUBMISSION_TO_HMCTS,
+      caseUserRole: undefined,
       caseType: undefined,
       typeOfClaim: undefined,
       caseTypeId: undefined,

--- a/src/test/unit/mocks/mockUserCaseComplete.ts
+++ b/src/test/unit/mocks/mockUserCaseComplete.ts
@@ -124,6 +124,7 @@ export default {
   state: CaseState.AWAITING_SUBMISSION_TO_HMCTS,
   caseType: CaseType.SINGLE,
   caseTypeId: CaseTypeId.ENGLAND_WALES,
+  caseUserRole: 'CREATOR',
   claimantRepresentedQuestion: YesOrNo.YES,
   avgWeeklyHrs: 5,
   claimantPensionContribution: YesOrNoOrNotSure.YES,

--- a/src/test/unit/mocks/mockedApiData.ts
+++ b/src/test/unit/mocks/mockedApiData.ts
@@ -29,6 +29,7 @@ export const mockedApiData: CaseApiDataResponse = {
   created_date: '2022-08-19T09:19:25.79202',
   last_modified: '2022-08-19T09:19:25.817549',
   case_data: {
+    caseUserRole: 'CREATOR',
     ethosCaseReference: '123456/2022',
     feeGroupReference: '1234',
     caseType: CaseType.SINGLE,

--- a/src/test/unit/views/claimant-applications.test.ts
+++ b/src/test/unit/views/claimant-applications.test.ts
@@ -207,6 +207,8 @@ describe('Claimant Applications page - My claims / Representing tabs', () => {
     personalApp.userCase.claimantRepresentedQuestion = YesOrNo.NO;
     const representingApp = JSON.parse(JSON.stringify(mockApplications[2]));
     representingApp.userCase.claimantRepresentedQuestion = YesOrNo.YES;
+    representingApp.userCase.firstName = 'Alice';
+    representingApp.userCase.lastName = 'Claimant';
 
     getUserCasesMock.mockResolvedValue([
       { id: '12454', state: CaseState.AWAITING_SUBMISSION_TO_HMCTS } as CaseWithId,
@@ -240,5 +242,31 @@ describe('Claimant Applications page - My claims / Representing tabs', () => {
     const representingPanel = tabbedHtml.getElementById('representing');
     expect(myClaimsPanel).to.not.be.null;
     expect(representingPanel).to.not.be.null;
+  });
+
+  it('should show the Claimant column (replacing Respondents) only in the "Representing others" tab', () => {
+    const representingPanel = tabbedHtml.getElementById('representing');
+    const myClaimsPanel = tabbedHtml.getElementById('my-claims');
+
+    // Representing table: has the Claimant column + name, and no Respondents column.
+    expect(representingPanel.innerHTML).contains(
+      '>' + claimantApplicationsJSON.claimantNameCol + '<',
+      'Claimant column heading should exist in the representing table'
+    );
+    expect(representingPanel.innerHTML).contains('Alice Claimant', 'Represented claimant name should be shown');
+    expect(representingPanel.innerHTML).to.not.contain(
+      '>' + claimantApplicationsJSON.col4 + '<',
+      'Respondents column should be dropped from the representing table'
+    );
+
+    // My claims table: keeps Respondents, has no Claimant column.
+    expect(myClaimsPanel.innerHTML).contains(
+      '>' + claimantApplicationsJSON.col4 + '<',
+      'Respondents column should remain in the My claims table'
+    );
+    expect(myClaimsPanel.innerHTML).to.not.contain(
+      '>' + claimantApplicationsJSON.claimantNameCol + '<',
+      'Claimant column should not appear in the My claims table'
+    );
   });
 });


### PR DESCRIPTION
### JIRA link

### Change description

 Split claimant applications into role-based tabs on /claimant-applications                                                                                                                    
                                                                                                                                                                                                
  - Single GET /cases/user-cases call now returns the user's own claims (CREATOR) and the claims they represent (CLAIMANTNONLEGALREPRESENTATIVE); each case carries its matched role in         
  caseUserRole.                                                                                                                                                                                 
  - Frontend reads caseUserRole (top-level or case_data) via fromApiFormat and splits applications into two tabs:                                                                               
    - My ET1 claims — CREATOR cases                                                                                                                                                             
    - ET1 claims for others — CLAIMANTNONLEGALREPRESENTATIVE cases                                                                                                                              
    - Tabs show only when the user has both; otherwise, a single list (with a heading only for the representing-only case).                                                                      
  - Label updates: "ET1 Applications" → "ET1 Claims", "Draft/Submitted applications" → "Draft/Submitted claims", plus the two tab labels.                                                       
  - "ET1 claims for others" table: shows a Claimant column in place of Respondents.                           

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
