### PR TITLE
fix: update undici and ip-address CVE resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,8 +192,8 @@
     "underscore": "^1.13.8",
     "yauzl": "3.2.1",
     "picomatch": "^4.0.4",
-    "ip-address": "^10.1.1",
-    "undici": "^7.25.0",
+    "ip-address": "10.3.1",
+    "undici": "7.29.0",
     "body-parser": "^1.20.6",
     "js-yaml@npm:^4.1.1": "npm:4.3.0",
     "immutable": "^5.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11584,10 +11584,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1
+"ip-address@npm:10.3.1":
+  version: 10.3.1
+  resolution: "ip-address@npm:10.3.1"
+  checksum: 10/cc0d5b9953acb4114990a3887e0701f8fe843903811f982cf2856cd307c5fb6cdca426ad16c39a1f4950091935c8be4d42631a443f797a96626cce161fffed41
   languageName: node
   linkType: hard
 
@@ -18660,10 +18660,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.25.0":
-  version: 7.28.0
-  resolution: "undici@npm:7.28.0"
-  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
+"undici@npm:7.29.0":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10/ca73639071bdcbc41e57be1800847fa18f86f8fbf7a5641ff9899f7bbb6f5cecdd593e225f5fd94e31703dcbfaea4a722a3b81cab90c5c4e2b406aec1ae55732
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- pin transitive `undici` to 7.29.0 to remediate the reported cache handling, response desynchronization, cookie injection, and CRLF injection vulnerabilities
- pin transitive `ip-address` to 10.3.1 to remediate the reported SSRF and trust-boundary bypass vulnerabilities
- refresh the Yarn lockfile

## Validation
- `yarn install --immutable --mode=skip-build`
- `yarn why undici` resolves all affected paths to 7.29.0
- `yarn why ip-address` resolves all affected paths to 10.3.1
- `yarn test:translations` (518 passed)
